### PR TITLE
chore(model): add readiness endpoint

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -762,7 +762,14 @@
         "method": "GET",
         "timeout": "5s",
         "input_query_strings": []
-      }
+      },
+      {
+        "endpoint": "/v1alpha/ready/model",
+        "url_pattern": "/v1alpha/ready/model",
+        "method": "GET",
+        "timeout": "60s",
+        "input_query_strings": []
+      }      
     ],
     "grpc_auth": [
       {


### PR DESCRIPTION
Because

- `model-backend` has a readiness status pre-conditioning on Temporal `add-search-attributes`

This commit

- add the readiness check endpoint
