### PR TITLE
chore: add page_size and page_token in model definition list API

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -749,7 +749,9 @@
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
-          "view"
+          "view",
+          "page_size",
+          "page_token"
         ]
       },
       {


### PR DESCRIPTION
Because

- support pagination in list model definitions API but api-gateway do not pass page_size and page_token to the model-backend

This commit

- add input query for page_size and page_token in the list model definition API for the model-backend
