### PR TITLE
chore(metrics): fix invalid metric naming prefix

### DIFF
--- a/config/templates/opencensus.tmpl
+++ b/config/templates/opencensus.tmpl
@@ -9,7 +9,7 @@
   "exporters": {
     "prometheus": {
       "port": {{ .ports.api_gateway_metrics_port }},
-      "namespace": "api-gateway"
+      "namespace": "api_gateway"
     },
     "jaeger": {
       "endpoint": "http://{{ .hosts.jaeger_host }}:{{ .ports.jaeger_port }}/api/traces",


### PR DESCRIPTION
Because

- export metrics failed because of invalid metric name with "-"

This commit

- fix it and replace with underscore
