### PR TITLE
chore(connector): add input_query_strings `filter` for connectors and connector-definitions

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -235,7 +235,8 @@
         "input_query_strings": [
           "view",
           "page_size",
-          "page_token"
+          "page_token",
+          "filter"
         ]
       },
       {
@@ -336,7 +337,8 @@
         "input_query_strings": [
           "page_size",
           "page_token",
-          "view"
+          "view",
+          "filter"
         ]
       },
       {


### PR DESCRIPTION
Because

- we added a new filter param for connectors and connector-definitions endpoints

This commit

- propagate the `filter`
