### PR TITLE
chore(vdp): add connector and metric endpoints

### DIFF
--- a/config/base/settings-env/endpoints.json
+++ b/config/base/settings-env/endpoints.json
@@ -62,6 +62,35 @@
           "page_token",
           "filter"
         ]
+      },
+      {
+        "endpoint": "/v1alpha/metrics/vdp/pipeline/charts",
+        "url_pattern": "/v1alpha/metrics/vdp/pipeline/charts",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "filter"
+        ]
+      },
+      {
+        "endpoint": "/v1alpha/metrics/vdp/connector/executes",
+        "url_pattern": "/v1alpha/metrics/vdp/connector/executes",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "page_size",
+          "page_token",
+          "filter"
+        ]
+      },
+      {
+        "endpoint": "/v1alpha/metrics/vdp/connector/charts",
+        "url_pattern": "/v1alpha/metrics/vdp/connector/charts",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "filter"
+        ]
       }
     ],
     "no_auth": [
@@ -127,6 +156,25 @@
       {
         "endpoint": "/base.mgmt.v1alpha.MgmtPublicService/ListPipelineTriggerRecords",
         "url_pattern": "/base.mgmt.v1alpha.MgmtPublicService/ListPipelineTriggerRecords",
+        "method": "POST",
+        "timeout": "30s"
+      },
+      {
+        "endpoint": "/base.mgmt.v1alpha.MgmtPublicService/ListPipelineTriggerChartRecords",
+        "url_pattern": "/base.mgmt.v1alpha.MgmtPublicService/ListPipelineTriggerChartRecords",
+        "method": "POST",
+        "timeout": "30s"
+      }
+      ,
+      {
+        "endpoint": "/base.mgmt.v1alpha.MgmtPublicService/ListConnectorExecuteRecords",
+        "url_pattern": "/base.mgmt.v1alpha.MgmtPublicService/ListConnectorExecuteRecords",
+        "method": "POST",
+        "timeout": "30s"
+      },
+      {
+        "endpoint": "/base.mgmt.v1alpha.MgmtPublicService/ListConnectorExecuteChartRecords",
+        "url_pattern": "/base.mgmt.v1alpha.MgmtPublicService/ListConnectorExecuteChartRecords",
         "method": "POST",
         "timeout": "30s"
       }


### PR DESCRIPTION
Because

- support connector dashboard
- support time window aggregation for dashboard chart render

This commit

- add chart and connector metric endpoints
