### PR TITLE
chore(metric): add missing query string for listing charts

### DIFF
--- a/config/base/settings-env/endpoints.json
+++ b/config/base/settings-env/endpoints.json
@@ -69,6 +69,7 @@
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
+          "aggregation_window",
           "filter"
         ]
       },
@@ -89,6 +90,7 @@
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
+          "aggregation_window",
           "filter"
         ]
       }


### PR DESCRIPTION
Because

- add missing query string for listing charts

This commit

- add missing query string for listing charts
