### PR TITLE
chore(vdp): add operator-definitions endpoint

### DIFF
--- a/config/vdp/settings-env/endpoints.json
+++ b/config/vdp/settings-env/endpoints.json
@@ -129,6 +129,27 @@
         "method": "GET",
         "timeout": "5s",
         "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/operator-definitions",
+        "url_pattern": "/v1alpha/operator-definitions",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "page_size",
+          "page_token",
+          "view",
+          "filter"
+        ]
+      },
+      {
+        "endpoint": "/v1alpha/operator-definitions/{id}",
+        "url_pattern": "/v1alpha/operator-definitions/{id}",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "view"
+        ]
       }
     ],
     "grpc_auth": [
@@ -233,6 +254,18 @@
       {
         "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/Readiness",
         "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/Readiness",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/ListOperatorDefinitions",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/ListOperatorDefinitions",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/GetOperatorDefinition",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/GetOperatorDefinition",
         "method": "POST",
         "timeout": "5s"
       }


### PR DESCRIPTION
Because

- we need a new endpoint for operator-definitions

This commit

- add operator-definitions endpoint
