### PR TITLE
chore(vdp): add namespace in endpoints

### DIFF
--- a/config/vdp/settings-env/endpoints.json
+++ b/config/vdp/settings-env/endpoints.json
@@ -137,14 +137,14 @@
         "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/trigger",
         "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/trigger",
         "method": "POST",
-        "timeout": "30s",
+        "timeout": "600s",
         "input_query_strings": []
       },
       {
         "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/triggerAsync",
         "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/triggerAsync",
         "method": "POST",
-        "timeout": "30s",
+        "timeout": "600s",
         "input_query_strings": []
       },
       {

--- a/config/vdp/settings-env/endpoints.json
+++ b/config/vdp/settings-env/endpoints.json
@@ -169,8 +169,8 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/release",
-        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/release",
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/rename",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/rename",
         "method": "POST",
         "timeout": "30s",
         "input_query_strings": []

--- a/config/vdp/settings-env/endpoints.json
+++ b/config/vdp/settings-env/endpoints.json
@@ -136,14 +136,14 @@
       {
         "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/trigger",
         "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/trigger",
-        "method": "DELETE",
+        "method": "POST",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
         "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/triggerAsync",
         "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/triggerAsync",
-        "method": "DELETE",
+        "method": "POST",
         "timeout": "30s",
         "input_query_strings": []
       },

--- a/config/vdp/settings-env/endpoints.json
+++ b/config/vdp/settings-env/endpoints.json
@@ -10,13 +10,6 @@
       {
         "endpoint": "/v1alpha/pipelines",
         "url_pattern": "/v1alpha/pipelines",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/pipelines",
-        "url_pattern": "/v1alpha/pipelines",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
@@ -27,8 +20,27 @@
         ]
       },
       {
-        "endpoint": "/v1alpha/pipelines/{id}",
-        "url_pattern": "/v1alpha/pipelines/{id}",
+        "endpoint": "/v1alpha/users/{user_id}/pipelines",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "view",
+          "page_size",
+          "page_token",
+          "filter"
+        ]
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
@@ -36,22 +48,22 @@
         ]
       },
       {
-        "endpoint": "/v1alpha/pipelines/{id}",
-        "url_pattern": "/v1alpha/pipelines/{id}",
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}",
         "method": "PATCH",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/pipelines/{id}",
-        "url_pattern": "/v1alpha/pipelines/{id}",
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}",
         "method": "DELETE",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/pipelines/{id}/lookUp",
-        "url_pattern": "/v1alpha/pipelines/{id}/lookUp",
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/lookUp",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/lookUp",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
@@ -59,59 +71,108 @@
         ]
       },
       {
-        "endpoint": "/v1alpha/pipelines/{id}/watch",
-        "url_pattern": "/v1alpha/pipelines/{id}/watch",
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/rename",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/rename",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/trigger",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/trigger",
+        "method": "POST",
+        "timeout": "600s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/triggerAsync",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/triggerAsync",
+        "method": "POST",
+        "timeout": "600s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "view",
+          "page_size",
+          "page_token",
+          "filter"
+        ]
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "view"
+        ]
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}",
+        "method": "PATCH",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}",
+        "method": "DELETE",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/trigger",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/trigger",
+        "method": "DELETE",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/triggerAsync",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/triggerAsync",
+        "method": "DELETE",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/set_default",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/set_default",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/restore",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/restore",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/watch",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/watch",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/pipelines/{id}/activate",
-        "url_pattern": "/v1alpha/pipelines/{id}/activate",
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/release",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/release",
         "method": "POST",
         "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/pipelines/{id}/deactivate",
-        "url_pattern": "/v1alpha/pipelines/{id}/deactivate",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/pipelines/{id}/rename",
-        "url_pattern": "/v1alpha/pipelines/{id}/rename",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/pipelines/{id}/trigger",
-        "url_pattern": "/v1alpha/pipelines/{id}/trigger",
-        "method": "POST",
-        "timeout": "600s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/pipelines/{id}/triggerMultipart",
-        "url_pattern": "/v1alpha/pipelines/{id}/triggerMultipart",
-        "method": "POST",
-        "timeout": "600s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/pipelines/{id}/triggerAsync",
-        "url_pattern": "/v1alpha/pipelines/{id}/triggerAsync",
-        "method": "POST",
-        "timeout": "600s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/pipelines/{id}/triggerAsyncMultipart",
-        "url_pattern": "/v1alpha/pipelines/{id}/triggerAsyncMultipart",
-        "method": "POST",
-        "timeout": "600s",
         "input_query_strings": []
       },
       {
@@ -154,88 +215,100 @@
     ],
     "grpc_auth": [
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
         "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines",
         "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/CreateUserPipeline",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/CreateUserPipeline",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/ListUserPipelines",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/ListUserPipelines",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/GetUserPipeline",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/GetUserPipeline",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/UpdateUserPipeline",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/UpdateUserPipeline",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/DeleteUserPipeline",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/DeleteUserPipeline",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/LookUpUserPipeline",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/LookUpUserPipeline",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/RenameUserPipeline",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/RenameUserPipeline",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/WatchPipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/WatchPipeline",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerPipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerPipeline",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerUserPipeline",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerUserPipeline",
         "method": "POST",
         "timeout": "600s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerPipelineBinaryFileUpload",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerPipelineBinaryFileUpload",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncUserPipeline",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncUserPipeline",
         "method": "POST",
         "timeout": "600s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerUserPipelineRelease",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerUserPipelineRelease",
         "method": "POST",
         "timeout": "600s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipelineBinaryFileUpload",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipelineBinaryFileUpload",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncUserPipelineRelease",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncUserPipelineRelease",
         "method": "POST",
         "timeout": "600s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/WatchUserPipelineRelease",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/WatchUserPipelineRelease",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/SetDefaultUserPipelineRelease",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/SetDefaultUserPipelineRelease",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/RestoreUserPipelineRelease",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/RestoreUserPipelineRelease",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/RenameUserPipelineRelease",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/RenameUserPipelineRelease",
+        "method": "POST",
+        "timeout": "5s"
       },
       {
         "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/GetOperation",
@@ -276,6 +349,13 @@
       {
         "endpoint": "/v1alpha/connector-resources",
         "url_pattern": "/v1alpha/connector-resources",
+        "method": "POST",
+        "timeout": "360s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
@@ -286,15 +366,15 @@
         ]
       },
       {
-        "endpoint": "/v1alpha/connector-resources",
-        "url_pattern": "/v1alpha/connector-resources",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources",
         "method": "POST",
         "timeout": "360s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/connector-resources/{id}",
-        "url_pattern": "/v1alpha/connector-resources/{id}",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources/{id}",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources/{id}",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
@@ -302,22 +382,22 @@
         ]
       },
       {
-        "endpoint": "/v1alpha/connector-resources/{id}",
-        "url_pattern": "/v1alpha/connector-resources/{id}",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources/{id}",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources/{id}",
         "method": "PATCH",
         "timeout": "360s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/connector-resources/{id}",
-        "url_pattern": "/v1alpha/connector-resources/{id}",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources/{id}",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources/{id}",
         "method": "DELETE",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/connector-resources/{id}/lookUp",
-        "url_pattern": "/v1alpha/connector-resources/{id}/lookUp",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources/{id}/lookUp",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources/{id}/lookUp",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
@@ -325,43 +405,43 @@
         ]
       },
       {
-        "endpoint": "/v1alpha/connector-resources/{id}/watch",
-        "url_pattern": "/v1alpha/connector-resources/{id}/watch",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources/{id}/watch",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources/{id}/watch",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/connector-resources/{id}/connect",
-        "url_pattern": "/v1alpha/connector-resources/{id}/connect",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources/{id}/connect",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources/{id}/connect",
         "method": "POST",
         "timeout": "360s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/connector-resources/{id}/disconnect",
-        "url_pattern": "/v1alpha/connector-resources/{id}/disconnect",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources/{id}/disconnect",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources/{id}/disconnect",
         "method": "POST",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/connector-resources/{id}/rename",
-        "url_pattern": "/v1alpha/connector-resources/{id}/rename",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources/{id}/rename",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources/{id}/rename",
         "method": "POST",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/connector-resources/{id}/execute",
-        "url_pattern": "/v1alpha/connector-resources/{id}/execute",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources/{id}/execute",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources/{id}/execute",
         "method": "POST",
         "timeout": "360s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/connector-resources/{id}/testConnection",
-        "url_pattern": "/v1alpha/connector-resources/{id}/testConnection",
+        "endpoint": "/v1alpha/users/{user_id}/connector-resources/{id}/testConnection",
+        "url_pattern": "/v1alpha/users/{user_id}/connector-resources/{id}/testConnection",
         "method": "POST",
         "timeout": "360s",
         "input_query_strings": []
@@ -399,74 +479,80 @@
     ],
     "grpc_auth": [
       {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/CreateConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/CreateConnectorResource",
-        "method": "POST",
-        "timeout": "360s"
-      },
-      {
         "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/ListConnectorsResource",
         "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/ListConnectorsResource",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/GetConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/GetConnectorResource",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/UpdateConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/UpdateConnectorResource",
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/CreateUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/CreateUserConnectorResource",
         "method": "POST",
         "timeout": "360s"
       },
       {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/DeleteConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/DeleteConnectorResource",
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/ListUserConnectorsResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/ListUserConnectorsResource",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/LookUpConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/LookUpConnectorResource",
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/GetUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/GetUserConnectorResource",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/WatchConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/WatchConnectorResource",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/ConnectConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/ConnectConnectorResource",
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/UpdateUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/UpdateUserConnectorResource",
         "method": "POST",
         "timeout": "360s"
       },
       {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/DisconnectConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/DisconnectConnectorResource",
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/DeleteUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/DeleteUserConnectorResource",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/RenameConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/RenameConnectorResource",
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/LookUpUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/LookUpUserConnectorResource",
         "method": "POST",
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/ExecuteConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/ExecuteConnectorResource",
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/WatchUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/WatchUserConnectorResource",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/ConnectUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/ConnectUserConnectorResource",
         "method": "POST",
         "timeout": "360s"
       },
       {
-        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/TestConnectorResource",
-        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/TestConnectorResource",
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/DisconnectUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/DisconnectUserConnectorResource",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/RenameUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/RenameUserConnectorResource",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/ExecuteUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/ExecuteUserConnectorResource",
+        "method": "POST",
+        "timeout": "360s"
+      },
+      {
+        "endpoint": "/vdp.connector.v1alpha.ConnectorPublicService/TestUserConnectorResource",
+        "url_pattern": "/vdp.connector.v1alpha.ConnectorPublicService/TestUserConnectorResource",
         "method": "POST",
         "timeout": "360s"
       }


### PR DESCRIPTION
Because

- We would like to make the resources be public or shared to other users. The current structure can not support it since the api endpoint was designed for the users' own resources.

This commit

- refactor endpoints to support namespace
