### PR TITLE
chore(vdp): propagate `show_deleted` query param

### DIFF
--- a/config/model/settings-env/endpoints.json
+++ b/config/model/settings-env/endpoints.json
@@ -15,7 +15,8 @@
         "input_query_strings": [
           "view",
           "page_size",
-          "page_token"
+          "page_token",
+          "show_deleted"
         ]
       },
       {
@@ -35,7 +36,8 @@
         "input_query_strings": [
           "view",
           "page_size",
-          "page_token"
+          "page_token",
+          "show_deleted"
         ]
       },
       {

--- a/config/vdp/settings-env/endpoints.json
+++ b/config/vdp/settings-env/endpoints.json
@@ -16,7 +16,8 @@
           "view",
           "page_size",
           "page_token",
-          "filter"
+          "filter",
+          "show_deleted"
         ]
       },
       {
@@ -44,7 +45,8 @@
           "view",
           "page_size",
           "page_token",
-          "filter"
+          "filter",
+          "show_deleted"
         ]
       },
       {
@@ -116,7 +118,8 @@
           "page_size",
           "page_token",
           "view",
-          "filter"
+          "filter",
+          "show_deleted"
         ]
       },
       {
@@ -235,7 +238,8 @@
           "view",
           "page_size",
           "page_token",
-          "filter"
+          "filter",
+          "show_deleted"
         ]
       },
       {
@@ -256,7 +260,8 @@
           "view",
           "page_size",
           "page_token",
-          "filter"
+          "filter",
+          "show_deleted"
         ]
       },
       {
@@ -349,7 +354,8 @@
           "page_size",
           "page_token",
           "view",
-          "filter"
+          "filter",
+          "show_deleted"
         ]
       },
       {

--- a/config/vdp/settings-env/endpoints.json
+++ b/config/vdp/settings-env/endpoints.json
@@ -80,6 +80,13 @@
         "input_query_strings": []
       },
       {
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/validate",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/validate",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
         "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/trigger",
         "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/trigger",
         "method": "POST",
@@ -178,6 +185,12 @@
       {
         "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/RenameUserPipeline",
         "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/RenameUserPipeline",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/ValidateUserPipeline",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/ValidateUserPipeline",
         "method": "POST",
         "timeout": "5s"
       },


### PR DESCRIPTION
Because

- we added a `show_deleted` query param for the list operations in backend

This commit

- propagate `show_deleted` query param
- expose pipeline validation endpoint
