### PR TITLE
chore(base): add `Instill-Return-Traces` to allow_headers in CORS setting

### DIFF
--- a/config/share/templates/cors.tmpl
+++ b/config/share/templates/cors.tmpl
@@ -24,7 +24,9 @@
     "Authorization",
     "X-B3-Sampled",
     "X-B3-Spanid",
-    "X-B3-Traceid"
+    "X-B3-Traceid",
+    "Access-Control-Allow-Headers",
+    "Instill-Return-Traces"
   ],
   "allow_credentials": false,
   "debug": false


### PR DESCRIPTION
Because

- the CORS setting is not working for header `Instill-Return-Traces`

This commit

- add `Instill-Return-Traces` and `Access-Control-Allow-Headers` into CORS allow headers
