### PR TITLE
chore(base): rename header `Instill-Code` to `Instill-Share-Code`

### DIFF
--- a/config/share/settings-env/input_headers.json
+++ b/config/share/settings-env/input_headers.json
@@ -21,7 +21,7 @@
     "X-B3-Traceid",
     "jwt-sub",
     "Instill-Return-Traces",
-    "Instill-Code"
+    "Instill-Share-Code"
   ],
   "no_auth": [
     "Content-Type",
@@ -46,7 +46,7 @@
     "X-B3-Traceid",
     "jwt-sub",
     "Instill-Return-Traces",
-    "Instill-Code"
+    "Instill-Share-Code"
   ],
   "grpc_no_auth": [
     "Content-Type",

--- a/config/share/templates/cors.tmpl
+++ b/config/share/templates/cors.tmpl
@@ -27,7 +27,7 @@
     "X-B3-Traceid",
     "Access-Control-Allow-Headers",
     "Instill-Return-Traces",
-    "Instill-Code"
+    "Instill-Share-Code"
   ],
   "allow_credentials": false,
   "debug": false


### PR DESCRIPTION
Because

- the original header `Instill-Code` doesn't have a clear meaning

This commit

- rename header `Instill-Code` to `Instill-Share-Code`
