### PR TITLE
fix(base): fix pipeline release `setDefault` endpoint

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,7 +57,7 @@ $ docker exec -it api-gateway /bin/bash
 
 # In the api-gateway container
 $ cd grpc_proxy_plugin && go build -buildmode=plugin -buildvcs=false -o /usr/local/lib/krakend/plugin/grpc-proxy.so /api-gateway/grpc_proxy_plugin/client && cd /api-gateway # compile the KrakenD grpc-proxy plugin
-$ cd multi_auth_plugin && go build -buildmode=plugin -o /usr/local/lib/krakend/plugin/multi-auth.so /api-gateway/multi_auth_plugin/server && cd /api-gateway # compile the KrakenD multi-auth plugin
+$ cd multi_auth_plugin && go build -buildmode=plugin -buildvcs=false -o /usr/local/lib/krakend/plugin/multi-auth.so /api-gateway/multi_auth_plugin/server && cd /api-gateway # compile the KrakenD multi-auth plugin
 $ make config # generate KrakenD configuration file
 $ krakend run -c krakend.json
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,10 @@ RUN if [[ "$BUILDARCH" = "amd64" && "$TARGETARCH" = "arm64" ]] ; \
     cd /${SERVICE_NAME}/multi_auth_plugin && go mod download && \
     CGO_ENABLED=1 ARCH=$TARGETARCH GOARCH=$TARGETARCH GOHOSTARCH=$BUILDARCH \
     CC=aarch64-linux-musl-gcc EXTRA_LDFLAGS='-extld=aarch64-linux-musl-gcc' \
-    go build -buildmode=plugin -o multi-auth.so ./server; \
+    go build -buildmode=plugin -buildvcs=false -o multi-auth.so ./server; \
     else \
     cd /${SERVICE_NAME}/multi_auth_plugin && go mod download && \
-    CGO_ENABLED=1 go build -buildmode=plugin -o multi-auth.so ./server; fi
+    CGO_ENABLED=1 go build -buildmode=plugin -buildvcs=false -o multi-auth.so ./server; fi
 
 RUN cd /${SERVICE_NAME} && \
     git clone -b v2.0.12 https://github.com/lestrrat-go/jwx.git && \

--- a/config/base/settings-env/endpoints.json
+++ b/config/base/settings-env/endpoints.json
@@ -428,8 +428,8 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/set_default",
-        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/set_default",
+        "endpoint": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/setDefault",
+        "url_pattern": "/v1alpha/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}/setDefault",
         "method": "POST",
         "timeout": "30s",
         "input_query_strings": []


### PR DESCRIPTION
Because

- the path of `setDefault` is wrong

This commit

- fix pipeline release `setDefault` endpoint
- fix go build params for plugin
