### PR TITLE
chore(plugin): optimize multi-auth plugin

### DIFF
--- a/multi_auth_plugin/go.mod
+++ b/multi_auth_plugin/go.mod
@@ -1,4 +1,4 @@
-module plugin
+module multi_auth_plugin
 
 go 1.19
 

--- a/multi_auth_plugin/server/main.go
+++ b/multi_auth_plugin/server/main.go
@@ -50,9 +50,9 @@ func writeStatusUnauthorized(req *http.Request, w http.ResponseWriter) {
 		w.Header().Set("Content-Type", "application/grpc")
 		w.Header().Set("Trailer", "Grpc-Status")
 		w.Header().Add("Trailer", "Grpc-Message")
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Grpc-Status", "16")               // UNAUTHENTICATED
 		w.Header().Set("Grpc-Message", "Unauthenticated") // UNAUTHENTICATED
+		w.WriteHeader(http.StatusOK)
 	} else {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Header().Set("Content-Type", "application/json")

--- a/multi_auth_plugin/server/main.go
+++ b/multi_auth_plugin/server/main.go
@@ -73,6 +73,8 @@ func (r registerer) registerHandlers(ctx context.Context, extra map[string]inter
 		return h, errors.New("configuration not found")
 	}
 
+	client := &http.Client{}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		authorization := req.Header.Get("Authorization")
 
@@ -107,7 +109,6 @@ func (r registerer) registerHandlers(ctx context.Context, extra map[string]inter
 				return
 			}
 
-			client := &http.Client{}
 			loginResponseJson, err := client.Do(loginReq)
 			if err != nil {
 				writeStatusUnauthorized(req, w)
@@ -141,7 +142,7 @@ func (r registerer) registerHandlers(ctx context.Context, extra map[string]inter
 				return
 			}
 			reqValidate.Header = req.Header
-			resValidate, err := http.DefaultClient.Do(reqValidate)
+			resValidate, err := client.Do(reqValidate)
 
 			if err != nil {
 				writeStatusUnauthorized(req, w)


### PR DESCRIPTION
Because

- we don't need to re-order HTTP trailer in multi-auth plugin, it will be handled by grpc-proxy plugin 
- there are memory-leak risks when creating http client for every request

This commit

- fix `writeStatusUnauthorized` func
- update multi-auth plugin package name
- re-use http client
