### PR TITLE
chore(model): prolong timeout for deleteusermodel

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1147,7 +1147,7 @@
         "endpoint": "/model.model.v1alpha.ModelPublicService/DeleteUserModel",
         "url_pattern": "/model.model.v1alpha.ModelPublicService/DeleteUserModel",
         "method": "POST",
-        "timeout": "5s"
+        "timeout": "30s"
       },
       {
         "endpoint": "/model.model.v1alpha.ModelPublicService/RenameUserModel",


### PR DESCRIPTION
Because

- delete model takes longer for `ray` model

This commit

- prolong timeout for deleteusermodel
