### PR TITLE
feat(plugin): inject visitor id for public endpoints

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1316,8 +1316,8 @@
         "timeout": "600s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/ListConnectorsResource",
-        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/ListConnectorsResource",
+        "endpoint": "/vdp.pipeline.v1alpha.PipelinePublicService/ListConnectors",
+        "url_pattern": "/vdp.pipeline.v1alpha.PipelinePublicService/ListConnectors",
         "method": "POST",
         "timeout": "5s"
       },

--- a/multi_auth_plugin/go.mod
+++ b/multi_auth_plugin/go.mod
@@ -3,6 +3,7 @@ module multi_auth_plugin
 go 1.19
 
 require (
+	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	go.uber.org/zap v1.19.1
 	google.golang.org/grpc v1.53.0

--- a/multi_auth_plugin/go.sum
+++ b/multi_auth_plugin/go.sum
@@ -15,6 +15,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
+github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/multi_auth_plugin/server/main.go
+++ b/multi_auth_plugin/server/main.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/gofrs/uuid"
+
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 )
 
@@ -157,6 +159,11 @@ func (r registerer) registerHandlers(ctx context.Context, extra map[string]inter
 			} else {
 				writeStatusUnauthorized(req, w)
 			}
+
+		} else if authorization == "" {
+			visitorID, _ := uuid.NewV4()
+			req.Header.Set("jwt-sub", fmt.Sprintf("visitor:%s", visitorID.String()))
+			h.ServeHTTP(w, req)
 
 		} else {
 			req.URL.Path = "/internal" + req.URL.Path


### PR DESCRIPTION
Because

- We need to allow some endpoints reachable without login, we decided to generate a random uuid for identifying the visitor. We'll also use this visitor id for rate-limit purpose in the future

This commit

- inject visitor id for public endpoints
- fix connector endpoint bug
