### PR TITLE
chore(dockerfile): update default user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,3 +79,7 @@ COPY .env .env
 COPY Makefile Makefile
 COPY config config
 COPY scripts scripts
+
+RUN chown nobody:nogroup -R .
+
+USER nobody:nogroup


### PR DESCRIPTION
Because

- avoid having root as owner with service folder

This commit

- use `nobody:nogroup` as default user
