### PR TITLE
feat(vdp): propagate `visibility` query param for GET /pipelines endpoint

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -476,6 +476,7 @@
         "timeout": "30s",
         "input_query_strings": [
           "view",
+          "visibility",
           "page_size",
           "page_token",
           "filter",


### PR DESCRIPTION
Because

- we have a new query param for GET /pipelines endpoint

This commit

- propagate `visibility` query param for GET /pipelines endpoint
