### PR TITLE
fix(plugin): fix TCP connection leak

### DIFF
--- a/grpc_proxy_plugin/pkg/client.go
+++ b/grpc_proxy_plugin/pkg/client.go
@@ -69,6 +69,7 @@ func (r clientRegisterer) registerClients(_ context.Context, extra map[string]in
 		}
 
 		httpClient := http.Client{Transport: tr}
+		defer httpClient.CloseIdleConnections()
 
 		resp, err := httpClient.Do(req)
 		if err != nil {


### PR DESCRIPTION
Because

- The TCP connections didn't close in grpc-proxy, causing connection leak.

This commit

- Fix TCP connection leak
