### PR TITLE
ci(workflows): remove controller test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [pipeline-backend, controller-vdp]
+        component: [pipeline-backend]
     uses: instill-ai/vdp/.github/workflows/integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [model-backend, controller-model]
+        component: [model-backend]
     uses: instill-ai/model/.github/workflows/integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}


### PR DESCRIPTION
Because

- we retire `controller-vdp`
- `controller-model` does not have exposed endpoint to test

This commit

- remove `controller-vdp` and `controller-model` from test component list
