### PR TITLE
feat(vdp): add visibility query param for list pipelines endpoints

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -506,6 +506,7 @@
         "timeout": "30s",
         "input_query_strings": [
           "view",
+          "visibility",
           "page_size",
           "page_token",
           "filter",
@@ -661,6 +662,7 @@
         "timeout": "30s",
         "input_query_strings": [
           "view",
+          "visibility",
           "page_size",
           "page_token",
           "filter",


### PR DESCRIPTION
Because

- we have a `visibility` query param for list pipelines endpoints in pipeline-backend

This commit

- add `visibility` query param for list pipelines endpoints
