### PR TITLE
feat(vdp): add component definition list endpoint

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1047,6 +1047,18 @@
         "input_query_strings": []
       },
       {
+        "endpoint": "/v1beta/component-definitions",
+        "url_pattern": "/v1beta/component-definitions",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "page_size",
+          "page_token",
+          "view",
+          "filter"
+        ]
+      },
+      {
         "endpoint": "/v1beta/operator-definitions",
         "url_pattern": "/v1beta/operator-definitions",
         "method": "GET",


### PR DESCRIPTION
Because

- Website needs to access a paginated list of components

This commit

- Opens the endpoint introduced in https://github.com/instill-ai/protobufs/pull/274
