### PR TITLE
chore(config): add tls version

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,6 +9,13 @@ on:
       - main
 
 jobs:
+  build-push-image:
+    needs: backend
+    if: github.ref == 'refs/heads/main'
+    name: Build and push image
+    uses: instill-ai/api-gateway/.github/workflows/images.yml@main
+    secrets: inherit
+
   backend:
     strategy:
       fail-fast: false
@@ -19,10 +26,3 @@ jobs:
     with:
       component: ${{ matrix.component }}
       target: latest
-
-  build-push-image:
-    needs: backend
-    if: github.ref == 'refs/heads/main'
-    name: Build and push image
-    uses: instill-ai/api-gateway/.github/workflows/images.yml@main
-    secrets: inherit

--- a/config/base.json
+++ b/config/base.json
@@ -5,7 +5,9 @@
   {{ if and .tls.public_key .tls.private_key }}
   "tls": {
     "public_key": "{{ .tls.public_key }}",
-    "private_key": "{{ .tls.private_key }}"
+    "private_key": "{{ .tls.private_key }}",
+    "min_version": "TLS10",
+    "max_version": "TLS13"
   },
   {{ end }}
   "client_tls": {


### PR DESCRIPTION
Because

- load balancer provided by a cloud vendor supports only certain TLS versions

This commit

- add the `min_version` and `max_version` variables in the `tls` block
