### PR TITLE
chore(core): forward authorization header

### DIFF
--- a/config/share/settings-env/input_headers.json
+++ b/config/share/settings-env/input_headers.json
@@ -11,6 +11,7 @@
     "X-B3-Traceid"
   ],
   "http_auth": [
+    "Authorization",
     "Content-Type",
     "Content-Length",
     "X-Forwarded-For",
@@ -38,6 +39,7 @@
     "X-B3-Traceid"
   ],
   "grpc_auth": [
+    "Authorization",
     "Content-Type",
     "Content-Length",
     "X-Forwarded-For",


### PR DESCRIPTION
Because

- The Instill Model connector can't work properly in internal mode since the pods in different region clusters can't connect to each other, we decided to use external IP and bypass the user authorization.

This commit

- Fixes the multi-region connection problem by bypassing the user authorization header.