### PR TITLE
fix(registry): capture NotFound response in namespace check

### DIFF
--- a/plugins/registry/handler.go
+++ b/plugins/registry/handler.go
@@ -249,7 +249,7 @@ func (rh *registryHandler) relay(ctx context.Context, p registryHandlerParams) {
 		}
 		if err != nil {
 			switch grpcstatus.Convert(err).Code() {
-			case grpccodes.Unavailable:
+			case grpccodes.NotFound:
 				rh.handleNameUnknown(w, "model doesn't exist")
 			default:
 				logger.Error(req.URL.Path, "failed to validate namespace", err)


### PR DESCRIPTION
Because

- `model-backend:latest` returns a `NotFound` when the model doesn't exist. API gateway was capturing `Unavailable`.

This commit

- Updates the error code

# Notes

@heiruwu I don't know why when I was QAing this I was receiving an `Unavailable` code but having a look at the [source code](https://github.com/instill-ai/model-backend/blob/main/pkg/service/service.go#L344) a missing namespace should return `NotFound`, right? Or am I looking at the wrong method?
