### PR TITLE
feat(mgmt): add endpoints for user and organization avatars

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -293,6 +293,20 @@
         "method": "POST",
         "timeout": "30s",
         "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/users/{id}/avatar",
+        "url_pattern": "/v1beta/users/{id}/avatar",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/organizations/{id}/avatar",
+        "url_pattern": "/v1beta/organizations/{id}/avatar",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": []
       }
     ],
     "grpc_auth": [

--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1685,6 +1685,41 @@
         "input_query_strings": []
       },
       {
+        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/watch",
+        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/watch",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/deploy",
+        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/deploy",
+        "method": "POST",
+        "timeout": "86400s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/undeploy",
+        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/undeploy",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/trigger",
+        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/trigger",
+        "method": "POST",
+        "timeout": "600s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/trigger-multipart",
+        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/trigger-multipart",
+        "method": "POST",
+        "timeout": "600s",
+        "input_query_strings": []
+      },
+      {
         "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/versions",
         "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/versions",
         "method": "GET",
@@ -1797,6 +1832,41 @@
         "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/readme",
         "method": "GET",
         "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/watch",
+        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/watch",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/deploy",
+        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/deploy",
+        "method": "POST",
+        "timeout": "86400s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/undeploy",
+        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/undeploy",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/trigger",
+        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/trigger",
+        "method": "POST",
+        "timeout": "600s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/trigger-multipart",
+        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/trigger-multipart",
+        "method": "POST",
+        "timeout": "600s",
         "input_query_strings": []
       },
       {
@@ -1953,6 +2023,18 @@
         "timeout": "5s"
       },
       {
+        "endpoint": "/model.model.v1alpha.ModelPublicService/DeployUserModel",
+        "url_pattern": "/model.model.v1alpha.ModelPublicService/DeployUserModel",
+        "method": "POST",
+        "timeout": "86400s"
+      },
+      {
+        "endpoint": "/model.model.v1alpha.ModelPublicService/UndeployUserModel",
+        "url_pattern": "/model.model.v1alpha.ModelPublicService/UndeployUserModel",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
         "endpoint": "/model.model.v1alpha.ModelPublicService/GetUserModelCard",
         "url_pattern": "/model.model.v1alpha.ModelPublicService/GetUserModelCard",
         "method": "POST",
@@ -2039,6 +2121,18 @@
       {
         "endpoint": "/model.model.v1alpha.ModelPublicService/UnpublishOrganizationModel",
         "url_pattern": "/model.model.v1alpha.ModelPublicService/UnpublishOrganizationModel",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/model.model.v1alpha.ModelPublicService/DeployOrganizationModel",
+        "url_pattern": "/model.model.v1alpha.ModelPublicService/DeployOrganizationModel",
+        "method": "POST",
+        "timeout": "86400s"
+      },
+      {
+        "endpoint": "/model.model.v1alpha.ModelPublicService/UndeployOrganizationModel",
+        "url_pattern": "/model.model.v1alpha.ModelPublicService/UndeployOrganizationModel",
         "method": "POST",
         "timeout": "5s"
       },


### PR DESCRIPTION
Because

- Putting the avatar as base64 in the pipeline response is not a good choice. We should provide a link for the Console to fetch the avatar asynchronously.

This commit

- Adds endpoints for user and organization avatars.