### PR TITLE
feat(vdp): expose pipeline secrets endpoints

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1050,6 +1050,84 @@
         "method": "POST",
         "timeout": "360s",
         "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/user/secrets",
+        "url_pattern": "/v1beta/user/secrets",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/user/secrets",
+        "url_pattern": "/v1beta/user/secrets",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "page_size",
+          "page_token",
+          "filter"
+        ]
+      },
+      {
+        "endpoint": "/v1beta/user/secrets/{secret_id}",
+        "url_pattern": "/v1beta/user/secrets/{secret_id}",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/user/secrets/{secret_id}",
+        "url_pattern": "/v1beta/user/secrets/{secret_id}",
+        "method": "PATCH",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/user/secrets/{secret_id}",
+        "url_pattern": "/v1beta/user/secrets/{secret_id}",
+        "method": "DELETE",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/organizations/{organization_id}/secrets",
+        "url_pattern": "/v1beta/organizations/{organization_id}/secrets",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/organizations/{organization_id}/secrets",
+        "url_pattern": "/v1beta/organizations/{organization_id}/secrets",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "page_size",
+          "page_token",
+          "filter"
+        ]
+      },
+      {
+        "endpoint": "/v1beta/organizations/{organization_id}/secrets/{secret_id}",
+        "url_pattern": "/v1beta/organizations/{organization_id}/secrets/{secret_id}",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/organizations/{organization_id}/secrets/{secret_id}",
+        "url_pattern": "/v1beta/organizations/{organization_id}/secrets/{secret_id}",
+        "method": "PATCH",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/organizations/{organization_id}/secrets/{secret_id}",
+        "url_pattern": "/v1beta/organizations/{organization_id}/secrets/{secret_id}",
+        "method": "DELETE",
+        "timeout": "30s",
+        "input_query_strings": []
       }
     ],
     "no_auth": [
@@ -1579,6 +1657,66 @@
       {
         "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition",
         "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/CreateUserSecret",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/CreateUserSecret",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/ListUserSecrets",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/ListUserSecrets",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/GetUserSecret",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/GetUserSecret",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/UpdateUserSecret",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/UpdateUserSecret",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/DeleteUserSecret",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/DeleteUserSecret",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/CreateOrganizationSecret",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/CreateOrganizationSecret",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/ListOrganizationSecrets",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/ListOrganizationSecrets",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/GetOrganizationSecret",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/GetOrganizationSecret",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/UpdateOrganizationSecret",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/UpdateOrganizationSecret",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/DeleteOrganizationSecret",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/DeleteOrganizationSecret",
         "method": "POST",
         "timeout": "5s"
       }


### PR DESCRIPTION
Because

- We are going to provide a feature that allows users to store secrets under their own namespace or the organization namespaces, the pipeline recipe can reference these secrets.

This commit

- Exposes pipeline secrets endpoints.
