### PR TITLE
feat(mgmt): add credit public endpoints

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -208,6 +208,13 @@
         "input_query_strings": []
       },
       {
+        "endpoint": "/v1beta/{owner_type}/{id}/credit",
+        "url_pattern": "/v1beta/{owner_type}/{id}/credit",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
         "endpoint": "/v1beta/metrics/vdp/pipeline/triggers",
         "url_pattern": "/v1beta/metrics/vdp/pipeline/triggers",
         "method": "GET",
@@ -415,6 +422,12 @@
       {
         "endpoint": "/core.mgmt.v1beta.MgmtPublicService/CreateToken",
         "url_pattern": "/core.mgmt.v1beta.MgmtPublicService/CreateToken",
+        "method": "POST",
+        "timeout": "30s"
+      },
+      {
+        "endpoint": "/core.mgmt.v1beta.MgmtPublicService/GetRemainingCredit",
+        "url_pattern": "/core.mgmt.v1beta.MgmtPublicService/GetRemainingCredit",
         "method": "POST",
         "timeout": "30s"
       },


### PR DESCRIPTION
Because

- https://github.com/instill-ai/protobufs/pull/304 introduced the public credit endpoint for getting the remaining credit

This commit

- Add public endpoints (HTTP, gRPC) to `api-gateway`
