### PR TITLE
chore(mgmt): revert add credit public endpoints (#168)

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -208,13 +208,6 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/{owner_type}/{id}/credit",
-        "url_pattern": "/v1beta/{owner_type}/{id}/credit",
-        "method": "GET",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
         "endpoint": "/v1beta/metrics/vdp/pipeline/triggers",
         "url_pattern": "/v1beta/metrics/vdp/pipeline/triggers",
         "method": "GET",
@@ -422,12 +415,6 @@
       {
         "endpoint": "/core.mgmt.v1beta.MgmtPublicService/CreateToken",
         "url_pattern": "/core.mgmt.v1beta.MgmtPublicService/CreateToken",
-        "method": "POST",
-        "timeout": "30s"
-      },
-      {
-        "endpoint": "/core.mgmt.v1beta.MgmtPublicService/GetRemainingCredit",
-        "url_pattern": "/core.mgmt.v1beta.MgmtPublicService/GetRemainingCredit",
         "method": "POST",
         "timeout": "30s"
       },


### PR DESCRIPTION
Because

- The Credit API should only be exposed on the Cloud services. Since Credit is used to execute connectors with the Instill secrets, CE users won't be able to use credit.


This commit

- Reverts commit 8643c26a220524bf99e6f8eddef4c23b7e12dcb4.
