### PR TITLE
feat(vdp): adjust user secrets endpoint

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1052,15 +1052,15 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/user/secrets",
-        "url_pattern": "/v1beta/user/secrets",
+        "endpoint": "/v1beta/users/{user_id}/secrets",
+        "url_pattern": "/v1beta/users/{user_id}/secrets",
         "method": "POST",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/user/secrets",
-        "url_pattern": "/v1beta/user/secrets",
+        "endpoint": "/v1beta/users/{user_id}/secrets",
+        "url_pattern": "/v1beta/users/{user_id}/secrets",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
@@ -1070,22 +1070,22 @@
         ]
       },
       {
-        "endpoint": "/v1beta/user/secrets/{secret_id}",
-        "url_pattern": "/v1beta/user/secrets/{secret_id}",
+        "endpoint": "/v1beta/users/{user_id}/secrets/{secret_id}",
+        "url_pattern": "/v1beta/users/{user_id}/secrets/{secret_id}",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/user/secrets/{secret_id}",
-        "url_pattern": "/v1beta/user/secrets/{secret_id}",
+        "endpoint": "/v1beta/users/{user_id}/secrets/{secret_id}",
+        "url_pattern": "/v1beta/users/{user_id}/secrets/{secret_id}",
         "method": "PATCH",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/user/secrets/{secret_id}",
-        "url_pattern": "/v1beta/user/secrets/{secret_id}",
+        "endpoint": "/v1beta/users/{user_id}/secrets/{secret_id}",
+        "url_pattern": "/v1beta/users/{user_id}/secrets/{secret_id}",
         "method": "DELETE",
         "timeout": "30s",
         "input_query_strings": []


### PR DESCRIPTION
Because

- Originally, we used the `user/secrets` path for managing user secrets. However, this path style is not consistent with the pipeline endpoints. We should change it to `users/<userid>/secrets` for consistency.

This commit
- Adjusts the user secrets endpoint.