### PR TITLE
chore(vdp): fix endpoints json

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -810,7 +810,6 @@
         "input_query_strings": []
       },
       {
-      {
         "endpoint": "/v1beta/users/{user_id}/secrets",
         "url_pattern": "/v1beta/users/{user_id}/secrets",
         "method": "POST",


### PR DESCRIPTION
Because

- The endpoints json had wrong format. 

This commit

- Fixes endpoints json.
