### PR TITLE
feat(core): remove basePath for core, vdp, model and artifact endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ config:							## Output the composed KrakenD configuration
 	@jq . config/out.json > krakend.json
 	@rm config/out.json && rm -rf config/settings
 
+.PHONY: run
+run:
+	@krakend run -c krakend.json
+
 help:       					## Show this help.
 	@echo "\nMake Application using Docker-Compose files."
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m (default: help)\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)

--- a/config/base.json
+++ b/config/base.json
@@ -51,9 +51,13 @@
   },
   "endpoints": [
     {{- template "mgmt.tmpl" . }},
+    {{- template "mgmt_deprecate.tmpl" . }},
     {{- template "pipeline.tmpl" . }},
+    {{- template "pipeline_deprecate.tmpl" . }},
     {{- template "model.tmpl" . }},
+    {{- template "model_deprecate.tmpl" . }},
     {{- template "artifact.tmpl" . }},
+    {{- template "artifact_deprecate.tmpl" . }},
     {{- template "debug.tmpl" . }}
   ]
 }

--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -62,8 +62,8 @@
         ]
       },
       {
-        "endpoint": "/v1beta/users/{id}",
-        "url_pattern": "/v1beta/users/{id}",
+        "endpoint": "/v1beta/users/{user_id}",
+        "url_pattern": "/v1beta/users/{user_id}",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
@@ -83,29 +83,29 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/users/{id}/memberships",
-        "url_pattern": "/v1beta/users/{id}/memberships",
+        "endpoint": "/v1beta/users/{user_id}/memberships",
+        "url_pattern": "/v1beta/users/{user_id}/memberships",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/users/{id}/memberships/{membership_id}",
-        "url_pattern": "/v1beta/users/{id}/memberships/{membership_id}",
+        "endpoint": "/v1beta/users/{user_id}/memberships/{membership_id}",
+        "url_pattern": "/v1beta/users/{user_id}/memberships/{membership_id}",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/users/{id}/memberships/{membership_id}",
-        "url_pattern": "/v1beta/users/{id}/memberships/{membership_id}",
+        "endpoint": "/v1beta/users/{user_id}/memberships/{membership_id}",
+        "url_pattern": "/v1beta/users/{user_id}/memberships/{membership_id}",
         "method": "PUT",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/users/{id}/memberships/{membership_id}",
-        "url_pattern": "/v1beta/users/{id}/memberships/{membership_id}",
+        "endpoint": "/v1beta/users/{user_id}/memberships/{membership_id}",
+        "url_pattern": "/v1beta/users/{user_id}/memberships/{membership_id}",
         "method": "DELETE",
         "timeout": "30s",
         "input_query_strings": []
@@ -128,50 +128,50 @@
         ]
       },
       {
-        "endpoint": "/v1beta/organizations/{id}",
-        "url_pattern": "/v1beta/organizations/{id}",
+        "endpoint": "/v1beta/organizations/{organization_id}",
+        "url_pattern": "/v1beta/organizations/{organization_id}",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/organizations/{id}",
-        "url_pattern": "/v1beta/organizations/{id}",
+        "endpoint": "/v1beta/organizations/{organization_id}",
+        "url_pattern": "/v1beta/organizations/{organization_id}",
         "method": "PATCH",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/organizations/{id}",
-        "url_pattern": "/v1beta/organizations/{id}",
+        "endpoint": "/v1beta/organizations/{organization_id}",
+        "url_pattern": "/v1beta/organizations/{organization_id}",
         "method": "DELETE",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/organizations/{id}/memberships",
-        "url_pattern": "/v1beta/organizations/{id}/memberships",
+        "endpoint": "/v1beta/organizations/{organization_id}/memberships",
+        "url_pattern": "/v1beta/organizations/{organization_id}/memberships",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/organizations/{id}/memberships/{membership_id}",
-        "url_pattern": "/v1beta/organizations/{id}/memberships/{membership_id}",
+        "endpoint": "/v1beta/organizations/{organization_id}/memberships/{membership_id}",
+        "url_pattern": "/v1beta/organizations/{organization_id}/memberships/{membership_id}",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/organizations/{id}/memberships/{membership_id}",
-        "url_pattern": "/v1beta/organizations/{id}/memberships/{membership_id}",
+        "endpoint": "/v1beta/organizations/{organization_id}/memberships/{membership_id}",
+        "url_pattern": "/v1beta/organizations/{organization_id}/memberships/{membership_id}",
         "method": "PUT",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/organizations/{id}/memberships/{membership_id}",
-        "url_pattern": "/v1beta/organizations/{id}/memberships/{membership_id}",
+        "endpoint": "/v1beta/organizations/{organization_id}/memberships/{membership_id}",
+        "url_pattern": "/v1beta/organizations/{organization_id}/memberships/{membership_id}",
         "method": "DELETE",
         "timeout": "30s",
         "input_query_strings": []
@@ -263,15 +263,15 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/users/{id}/avatar",
-        "url_pattern": "/v1beta/users/{id}/avatar",
+        "endpoint": "/v1beta/users/{user_id}/avatar",
+        "url_pattern": "/v1beta/users/{user_id}/avatar",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/organizations/{id}/avatar",
-        "url_pattern": "/v1beta/organizations/{id}/avatar",
+        "endpoint": "/v1beta/organizations/{organization_id}/avatar",
+        "url_pattern": "/v1beta/organizations/{organization_id}/avatar",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []

--- a/config/share/templates/artifact_deprecate.tmpl
+++ b/config/share/templates/artifact_deprecate.tmpl
@@ -4,7 +4,7 @@
 {{- range $idx, $endpoint := $endpoints.http_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "{{ .endpoint }}",
+  "endpoint": "/artifact{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -40,7 +40,7 @@
   ]
 },
 {
-  "endpoint": "/internal{{ .endpoint }}",
+  "endpoint": "/internal/artifact{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -81,7 +81,7 @@
 {{- range $idx, $endpoint := $endpoints.no_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "{{ .endpoint }}",
+  "endpoint": "/artifact{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -115,7 +115,7 @@
   ]
 },
 {
-  "endpoint": "/internal{{ .endpoint }}",
+  "endpoint": "/internal/artifact{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -149,51 +149,3 @@
   ]
 }
 {{- end}}
-,
-{{- range $idx, $endpoint := $endpoints.grpc_no_auth }}
-{{- if $idx -}},{{ end }}
-{
-  "endpoint": "{{ .endpoint }}",
-  "method": "{{ .method }}",
-  "timeout": "{{ .timeout }}",
-  "output_encoding": "no-op",
-  "input_headers": {{ marshal $input_headers.grpc_no_auth }},
-  "backend": [
-    {
-      "url_pattern": "{{ .url_pattern }}",
-      "host": {{ marshal $host }},
-      "sd": "static",
-      "method": "{{ .method }}",
-      "disable_host_sanitize": false,
-      "extra_config": {
-        "plugin/http-client": {
-          "name": "grpc-proxy-client",
-          "grpc-proxy-client": {}
-        }
-      }
-    }
-  ]
-},
-{
-  "endpoint": "/internal/{{ .endpoint }}",
-  "method": "{{ .method }}",
-  "timeout": "{{ .timeout }}",
-  "output_encoding": "no-op",
-  "input_headers": {{ marshal $input_headers.grpc_no_auth }},
-  "backend": [
-    {
-      "url_pattern": "{{ .url_pattern }}",
-      "host": {{ marshal $host }},
-      "sd": "static",
-      "method": "{{ .method }}",
-      "disable_host_sanitize": false,
-      "extra_config": {
-        "plugin/http-client": {
-          "name": "grpc-proxy-client",
-          "grpc-proxy-client": {}
-        }
-      }
-    }
-  ]
-}
-{{- end }}

--- a/config/share/templates/mgmt.tmpl
+++ b/config/share/templates/mgmt.tmpl
@@ -4,7 +4,7 @@
 {{- range $idx, $endpoint := $endpoints.basic }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "/core{{ .endpoint }}",
+  "endpoint": "{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -42,7 +42,7 @@
 {{- range $idx, $endpoint := $endpoints.http_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "/core{{ .endpoint }}",
+  "endpoint": "{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -77,7 +77,7 @@
   ]
 },
 {
-  "endpoint": "/internal/core{{ .endpoint }}",
+  "endpoint": "/internal{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -118,7 +118,7 @@
 {{- range $idx, $endpoint := $endpoints.no_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "/core{{ .endpoint }}",
+  "endpoint": "{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -152,7 +152,7 @@
   ]
 },
 {
-  "endpoint": "/internal/core{{ .endpoint }}",
+  "endpoint": "/internal{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":

--- a/config/share/templates/mgmt_deprecate.tmpl
+++ b/config/share/templates/mgmt_deprecate.tmpl
@@ -1,10 +1,48 @@
-{{ $host := .backends.artifact }}
+{{ $host := .backends.mgmt }}
 {{ $input_headers := .input_headers }}
-{{ $endpoints := .endpoints.artifact }}
+{{ $endpoints := .endpoints.mgmt }}
+{{- range $idx, $endpoint := $endpoints.basic }}
+{{- if $idx -}},{{ end }}
+{
+  "endpoint": "/core{{ .endpoint }}",
+  "method": "{{ .method }}",
+  {{- if len .input_query_strings -}}
+  "input_query_strings":
+  [
+    {{- range $qidx, $qstring := .input_query_strings }}
+    {{- if $qidx -}},{{ end }}
+    "{{ $qstring }}"
+    {{- end}}
+  ],
+  {{- end}}
+  "timeout": "{{ .timeout }}",
+  "input_headers": {{ marshal $input_headers.basic }},
+  "extra_config": {{ marshal .extra_config }},
+  "backend": [
+    {
+      "url_pattern": "{{ .url_pattern }}",
+      "host": {{ marshal $host }},
+      "sd": "static",
+      "method": "{{ .method }}",
+      "disable_host_sanitize": false,
+      "extra_config": {
+        "github.com/devopsfaith/krakend-martian": {
+          "header.Modifier": {
+            "scope": ["response"],
+            "name": "Backend",
+            "value": "management"
+          }
+        }
+      }
+    }
+  ]
+}
+{{- end}}
+,
 {{- range $idx, $endpoint := $endpoints.http_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "{{ .endpoint }}",
+  "endpoint": "/core{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -18,8 +56,7 @@
   "timeout": "{{ .timeout }}",
   "output_encoding": "no-op",
   "input_headers": {{ marshal $input_headers.http_auth }},
-  "extra_config": {
-  },
+  "extra_config": {},
   "backend": [
     {
       "url_pattern": "{{ .url_pattern }}",
@@ -32,7 +69,7 @@
           "header.Modifier": {
             "scope": ["response"],
             "name": "Backend",
-            "value": "artifact"
+            "value": "management"
           }
         }
       }
@@ -40,7 +77,7 @@
   ]
 },
 {
-  "endpoint": "/internal{{ .endpoint }}",
+  "endpoint": "/internal/core{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -69,79 +106,7 @@
           "header.Modifier": {
             "scope": ["response"],
             "name": "Backend",
-            "value": "artifact"
-          }
-        }
-      }
-    }
-  ]
-}
-{{- end }}
-,
-{{- range $idx, $endpoint := $endpoints.no_auth }}
-{{- if $idx -}},{{ end }}
-{
-  "endpoint": "{{ .endpoint }}",
-  "method": "{{ .method }}",
-  {{- if len .input_query_strings -}}
-  "input_query_strings":
-  [
-    {{- range $qidx, $qstring := .input_query_strings }}
-    {{- if $qidx -}},{{ end }}
-    "{{ $qstring }}"
-    {{- end}}
-  ],
-  {{- end}}
-  "timeout": "{{ .timeout }}",
-  "output_encoding": "no-op",
-  "input_headers": {{ marshal $input_headers.no_auth }},
-  "backend": [
-    {
-      "url_pattern": "{{ .url_pattern }}",
-      "host": {{ marshal $host }},
-      "sd": "static",
-      "method": "{{ .method }}",
-      "disable_host_sanitize": false,
-      "extra_config": {
-        "github.com/devopsfaith/krakend-martian": {
-          "header.Modifier": {
-            "scope": ["response"],
-            "name": "Backend",
-            "value": "artifact"
-          }
-        }
-      }
-    }
-  ]
-},
-{
-  "endpoint": "/internal{{ .endpoint }}",
-  "method": "{{ .method }}",
-  {{- if len .input_query_strings -}}
-  "input_query_strings":
-  [
-    {{- range $qidx, $qstring := .input_query_strings }}
-    {{- if $qidx -}},{{ end }}
-    "{{ $qstring }}"
-    {{- end}}
-  ],
-  {{- end}}
-  "timeout": "{{ .timeout }}",
-  "output_encoding": "no-op",
-  "input_headers": {{ marshal $input_headers.no_auth }},
-  "backend": [
-    {
-      "url_pattern": "{{ .url_pattern }}",
-      "host": {{ marshal $host }},
-      "sd": "static",
-      "method": "{{ .method }}",
-      "disable_host_sanitize": false,
-      "extra_config": {
-        "github.com/devopsfaith/krakend-martian": {
-          "header.Modifier": {
-            "scope": ["response"],
-            "name": "Backend",
-            "value": "artifact"
+            "value": "management"
           }
         }
       }
@@ -150,14 +115,23 @@
 }
 {{- end}}
 ,
-{{- range $idx, $endpoint := $endpoints.grpc_no_auth }}
+{{- range $idx, $endpoint := $endpoints.no_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "{{ .endpoint }}",
+  "endpoint": "/core{{ .endpoint }}",
   "method": "{{ .method }}",
+  {{- if len .input_query_strings -}}
+  "input_query_strings":
+  [
+    {{- range $qidx, $qstring := .input_query_strings }}
+    {{- if $qidx -}},{{ end }}
+    "{{ $qstring }}"
+    {{- end}}
+  ],
+  {{- end}}
   "timeout": "{{ .timeout }}",
   "output_encoding": "no-op",
-  "input_headers": {{ marshal $input_headers.grpc_no_auth }},
+  "input_headers": {{ marshal $input_headers.no_auth }},
   "backend": [
     {
       "url_pattern": "{{ .url_pattern }}",
@@ -166,20 +140,32 @@
       "method": "{{ .method }}",
       "disable_host_sanitize": false,
       "extra_config": {
-        "plugin/http-client": {
-          "name": "grpc-proxy-client",
-          "grpc-proxy-client": {}
+        "github.com/devopsfaith/krakend-martian": {
+          "header.Modifier": {
+            "scope": ["response"],
+            "name": "Backend",
+            "value": "management"
+          }
         }
       }
     }
   ]
 },
 {
-  "endpoint": "/internal/{{ .endpoint }}",
+  "endpoint": "/internal/core{{ .endpoint }}",
   "method": "{{ .method }}",
+  {{- if len .input_query_strings -}}
+  "input_query_strings":
+  [
+    {{- range $qidx, $qstring := .input_query_strings }}
+    {{- if $qidx -}},{{ end }}
+    "{{ $qstring }}"
+    {{- end}}
+  ],
+  {{- end}}
   "timeout": "{{ .timeout }}",
   "output_encoding": "no-op",
-  "input_headers": {{ marshal $input_headers.grpc_no_auth }},
+  "input_headers": {{ marshal $input_headers.no_auth }},
   "backend": [
     {
       "url_pattern": "{{ .url_pattern }}",
@@ -188,12 +174,15 @@
       "method": "{{ .method }}",
       "disable_host_sanitize": false,
       "extra_config": {
-        "plugin/http-client": {
-          "name": "grpc-proxy-client",
-          "grpc-proxy-client": {}
+        "github.com/devopsfaith/krakend-martian": {
+          "header.Modifier": {
+            "scope": ["response"],
+            "name": "Backend",
+            "value": "management"
+          }
         }
       }
     }
   ]
 }
-{{- end }}
+{{- end}}

--- a/config/share/templates/model.tmpl
+++ b/config/share/templates/model.tmpl
@@ -4,7 +4,7 @@
 {{- range $idx, $endpoint := $endpoints.http_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "/model{{ .endpoint }}",
+  "endpoint": "{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -39,7 +39,7 @@
   ]
 },
 {
-  "endpoint": "/internal/model{{ .endpoint }}",
+  "endpoint": "/internal{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -80,7 +80,7 @@
 {{- range $idx, $endpoint := $endpoints.no_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "/model{{ .endpoint }}",
+  "endpoint": "{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -114,7 +114,7 @@
   ]
 },
 {
-  "endpoint": "/internal/model{{ .endpoint }}",
+  "endpoint": "/internal{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":

--- a/config/share/templates/model_deprecate.tmpl
+++ b/config/share/templates/model_deprecate.tmpl
@@ -1,10 +1,10 @@
-{{ $host := .backends.artifact }}
+{{ $host := .backends.model }}
 {{ $input_headers := .input_headers }}
-{{ $endpoints := .endpoints.artifact }}
+{{ $endpoints := .endpoints.model }}
 {{- range $idx, $endpoint := $endpoints.http_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "{{ .endpoint }}",
+  "endpoint": "/model{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -18,8 +18,7 @@
   "timeout": "{{ .timeout }}",
   "output_encoding": "no-op",
   "input_headers": {{ marshal $input_headers.http_auth }},
-  "extra_config": {
-  },
+  "extra_config": {},
   "backend": [
     {
       "url_pattern": "{{ .url_pattern }}",
@@ -32,7 +31,7 @@
           "header.Modifier": {
             "scope": ["response"],
             "name": "Backend",
-            "value": "artifact"
+            "value": "model"
           }
         }
       }
@@ -40,7 +39,7 @@
   ]
 },
 {
-  "endpoint": "/internal{{ .endpoint }}",
+  "endpoint": "/internal/model{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -69,7 +68,7 @@
           "header.Modifier": {
             "scope": ["response"],
             "name": "Backend",
-            "value": "artifact"
+            "value": "model"
           }
         }
       }
@@ -81,7 +80,7 @@
 {{- range $idx, $endpoint := $endpoints.no_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "{{ .endpoint }}",
+  "endpoint": "/model{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -107,7 +106,7 @@
           "header.Modifier": {
             "scope": ["response"],
             "name": "Backend",
-            "value": "artifact"
+            "value": "model"
           }
         }
       }
@@ -115,7 +114,7 @@
   ]
 },
 {
-  "endpoint": "/internal{{ .endpoint }}",
+  "endpoint": "/internal/model{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -141,7 +140,7 @@
           "header.Modifier": {
             "scope": ["response"],
             "name": "Backend",
-            "value": "artifact"
+            "value": "model"
           }
         }
       }
@@ -149,51 +148,3 @@
   ]
 }
 {{- end}}
-,
-{{- range $idx, $endpoint := $endpoints.grpc_no_auth }}
-{{- if $idx -}},{{ end }}
-{
-  "endpoint": "{{ .endpoint }}",
-  "method": "{{ .method }}",
-  "timeout": "{{ .timeout }}",
-  "output_encoding": "no-op",
-  "input_headers": {{ marshal $input_headers.grpc_no_auth }},
-  "backend": [
-    {
-      "url_pattern": "{{ .url_pattern }}",
-      "host": {{ marshal $host }},
-      "sd": "static",
-      "method": "{{ .method }}",
-      "disable_host_sanitize": false,
-      "extra_config": {
-        "plugin/http-client": {
-          "name": "grpc-proxy-client",
-          "grpc-proxy-client": {}
-        }
-      }
-    }
-  ]
-},
-{
-  "endpoint": "/internal/{{ .endpoint }}",
-  "method": "{{ .method }}",
-  "timeout": "{{ .timeout }}",
-  "output_encoding": "no-op",
-  "input_headers": {{ marshal $input_headers.grpc_no_auth }},
-  "backend": [
-    {
-      "url_pattern": "{{ .url_pattern }}",
-      "host": {{ marshal $host }},
-      "sd": "static",
-      "method": "{{ .method }}",
-      "disable_host_sanitize": false,
-      "extra_config": {
-        "plugin/http-client": {
-          "name": "grpc-proxy-client",
-          "grpc-proxy-client": {}
-        }
-      }
-    }
-  ]
-}
-{{- end }}

--- a/config/share/templates/pipeline.tmpl
+++ b/config/share/templates/pipeline.tmpl
@@ -4,7 +4,7 @@
 {{- range $idx, $endpoint := $endpoints.http_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "/vdp{{ .endpoint }}",
+  "endpoint": "{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -40,7 +40,7 @@
   ]
 },
 {
-  "endpoint": "/internal/vdp{{ .endpoint }}",
+  "endpoint": "/internal{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -81,7 +81,7 @@
 {{- range $idx, $endpoint := $endpoints.no_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "/vdp{{ .endpoint }}",
+  "endpoint": "{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -115,7 +115,7 @@
   ]
 },
 {
-  "endpoint": "/internal/vdp{{ .endpoint }}",
+  "endpoint": "/internal{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":

--- a/config/share/templates/pipeline_deprecate.tmpl
+++ b/config/share/templates/pipeline_deprecate.tmpl
@@ -1,10 +1,10 @@
-{{ $host := .backends.artifact }}
+{{ $host := .backends.pipeline }}
 {{ $input_headers := .input_headers }}
-{{ $endpoints := .endpoints.artifact }}
+{{ $endpoints := .endpoints.pipeline }}
 {{- range $idx, $endpoint := $endpoints.http_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "{{ .endpoint }}",
+  "endpoint": "/vdp{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -32,7 +32,7 @@
           "header.Modifier": {
             "scope": ["response"],
             "name": "Backend",
-            "value": "artifact"
+            "value": "pipeline"
           }
         }
       }
@@ -40,7 +40,7 @@
   ]
 },
 {
-  "endpoint": "/internal{{ .endpoint }}",
+  "endpoint": "/internal/vdp{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -69,7 +69,7 @@
           "header.Modifier": {
             "scope": ["response"],
             "name": "Backend",
-            "value": "artifact"
+            "value": "pipeline"
           }
         }
       }
@@ -81,7 +81,7 @@
 {{- range $idx, $endpoint := $endpoints.no_auth }}
 {{- if $idx -}},{{ end }}
 {
-  "endpoint": "{{ .endpoint }}",
+  "endpoint": "/vdp{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -107,7 +107,7 @@
           "header.Modifier": {
             "scope": ["response"],
             "name": "Backend",
-            "value": "artifact"
+            "value": "pipeline"
           }
         }
       }
@@ -115,7 +115,7 @@
   ]
 },
 {
-  "endpoint": "/internal{{ .endpoint }}",
+  "endpoint": "/internal/vdp{{ .endpoint }}",
   "method": "{{ .method }}",
   {{- if len .input_query_strings -}}
   "input_query_strings":
@@ -141,7 +141,7 @@
           "header.Modifier": {
             "scope": ["response"],
             "name": "Backend",
-            "value": "artifact"
+            "value": "pipeline"
           }
         }
       }
@@ -149,51 +149,3 @@
   ]
 }
 {{- end}}
-,
-{{- range $idx, $endpoint := $endpoints.grpc_no_auth }}
-{{- if $idx -}},{{ end }}
-{
-  "endpoint": "{{ .endpoint }}",
-  "method": "{{ .method }}",
-  "timeout": "{{ .timeout }}",
-  "output_encoding": "no-op",
-  "input_headers": {{ marshal $input_headers.grpc_no_auth }},
-  "backend": [
-    {
-      "url_pattern": "{{ .url_pattern }}",
-      "host": {{ marshal $host }},
-      "sd": "static",
-      "method": "{{ .method }}",
-      "disable_host_sanitize": false,
-      "extra_config": {
-        "plugin/http-client": {
-          "name": "grpc-proxy-client",
-          "grpc-proxy-client": {}
-        }
-      }
-    }
-  ]
-},
-{
-  "endpoint": "/internal/{{ .endpoint }}",
-  "method": "{{ .method }}",
-  "timeout": "{{ .timeout }}",
-  "output_encoding": "no-op",
-  "input_headers": {{ marshal $input_headers.grpc_no_auth }},
-  "backend": [
-    {
-      "url_pattern": "{{ .url_pattern }}",
-      "host": {{ marshal $host }},
-      "sd": "static",
-      "method": "{{ .method }}",
-      "disable_host_sanitize": false,
-      "extra_config": {
-        "plugin/http-client": {
-          "name": "grpc-proxy-client",
-          "grpc-proxy-client": {}
-        }
-      }
-    }
-  ]
-}
-{{- end }}

--- a/plugins/multi-auth/main.go
+++ b/plugins/multi-auth/main.go
@@ -59,9 +59,9 @@ func (r registerer) registerHandlers(ctx context.Context, extra map[string]inter
 
 		if req.URL.String() == "/__health" {
 			h.ServeHTTP(w, req)
-		} else if req.URL.String() == "/core/v1beta/validate_token" {
+		} else if req.URL.String() == "/v1beta/validate_token" || req.URL.String() == "/core/v1beta/validate_token" {
 			h.ServeHTTP(w, req)
-		} else if req.URL.String() == "/core/v1beta/auth/login" {
+		} else if req.URL.String() == "/v1beta/auth/login" || req.URL.String() == "/core/v1beta/auth/login" {
 			h.ServeHTTP(w, req)
 		} else if strings.HasPrefix(authorization, "Basic ") || strings.HasPrefix(authorization, "basic ") {
 			basicAuth := strings.Split(authorization, " ")[1]


### PR DESCRIPTION
Because

- we've unified our Core, VDP, Model and Artifact products into a single product, we no longer need to use different endpoint prefixes for them.

This commit

- removes the `/core`, `/vdp`, `/model` and `/artifact` path prefixes.
- keep the old ones as deprecated endpoints, and we'll remove them after 2024/7/31.