### PR TITLE
feat(pipeline): add order_by param for pipeline endpoints

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -464,6 +464,7 @@
           "page_size",
           "page_token",
           "filter",
+          "order_by",
           "show_deleted"
         ]
       },
@@ -494,6 +495,7 @@
           "page_size",
           "page_token",
           "filter",
+          "order_by",
           "show_deleted"
         ]
       },
@@ -657,6 +659,7 @@
           "page_size",
           "page_token",
           "filter",
+          "order_by",
           "show_deleted"
         ]
       },


### PR DESCRIPTION
Because

- We are going to support pipeline sorting.

This commit

- Adds the `order_by` parameter for pipeline endpoints.