### PR TITLE
fix(registry): fix org membership check in registry plugin

### DIFF
--- a/plugins/registry/go.mod
+++ b/plugins/registry/go.mod
@@ -5,7 +5,7 @@ go 1.22.2
 require (
 	github.com/distribution/distribution v2.8.3+incompatible
 	github.com/frankban/quicktest v1.14.6
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240522171446-6efac14a674e
 	github.com/luraproject/lura v1.4.1
 	google.golang.org/grpc v1.63.2
 )

--- a/plugins/registry/go.sum
+++ b/plugins/registry/go.sum
@@ -21,6 +21,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0Q
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a h1:k4tq5qQQABKiQ7uuEN2K54jnx3eVaW/PQpZXBU/SGdQ=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240522171446-6efac14a674e h1:RIAH7ibosC8H6yC6MutFvjVdFyvSsV2gFwqQWlrqzmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240522171446-6efac14a674e/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/plugins/registry/handler.go
+++ b/plugins/registry/handler.go
@@ -205,6 +205,7 @@ func (rh *registryHandler) relay(ctx context.Context, p registryHandlerParams) {
 	// namespace is an organisation name where the user has the membership.
 	isOrganizationRepository := false
 	if namespace != p.userID {
+		ctx := withUserUIDAuth(ctx, p.userUID)
 		isOrganizationRepository = true
 
 		parent := fmt.Sprintf("users/%s", p.userID)


### PR DESCRIPTION
Because

- listUserMembership request is failing due to missing auth headers
```
[KRAKEND] 2024/05/23 - 06:20:44.630 ▶ ERROR /v2/instill-ai/llama3-8b-instruct/blobs/uploads/ failed to check organization rpc error: code = Unauthenticated desc = unauthenticated
```

This commit

- add necessary auth header to context
