### PR TITLE
feat(artifact): expose knowledge base endpoints

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -2053,6 +2053,30 @@
           "page_size",
           "page"
         ]
+      },
+      {
+        "endpoint": "/v1alpha/knowledge-base",
+        "url_pattern": "/v1alpha/knowledge-base",
+        "method": "POST",
+        "timeout": "30s"
+      },
+      {
+        "endpoint": "/v1alpha/users/{uid}/knowledge-base",
+        "url_pattern": "/v1alpha/users/{uid}/knowledge-base",
+        "method": "GET",
+        "timeout": "30s"
+      },
+      {
+        "endpoint": "/v1alpha/knowledge-base/{id}",
+        "url_pattern": "/v1alpha/knowledge-base/{id}",
+        "method": "PUT",
+        "timeout": "30s"
+      },
+      {
+        "endpoint": "/v1alpha/knowledge-base/{id}",
+        "url_pattern": "/v1alpha/knowledge-base/{id}",
+        "method": "DELETE",
+        "timeout": "30s"
       }
     ],
     "grpc_no_auth": [

--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -2058,25 +2058,51 @@
         "endpoint": "/v1alpha/knowledge-base",
         "url_pattern": "/v1alpha/knowledge-base",
         "method": "POST",
-        "timeout": "30s"
+        "timeout": "10s"
       },
       {
         "endpoint": "/v1alpha/users/{uid}/knowledge-base",
         "url_pattern": "/v1alpha/users/{uid}/knowledge-base",
         "method": "GET",
-        "timeout": "30s"
+        "timeout": "10s"
       },
       {
         "endpoint": "/v1alpha/knowledge-base/{id}",
         "url_pattern": "/v1alpha/knowledge-base/{id}",
         "method": "PUT",
-        "timeout": "30s"
+        "timeout": "10s"
       },
       {
         "endpoint": "/v1alpha/knowledge-base/{id}",
         "url_pattern": "/v1alpha/knowledge-base/{id}",
         "method": "DELETE",
-        "timeout": "30s"
+        "timeout": "10s"
+      }
+    ],
+    "grpc_auth": [
+      {
+        "endpoint": "/artifact.artifact.v1alpha.ArtifactPublicService/CreateKnowledgeBase",
+        "url_pattern": "/artifact.artifact.v1alpha.ArtifactPublicService/CreateKnowledgeBase",
+        "method": "POST",
+        "timeout": "10s"
+      },
+      {
+        "endpoint": "/artifact.artifact.v1alpha.ArtifactPublicService/ListKnowledgeBases",
+        "url_pattern": "/artifact.artifact.v1alpha.ArtifactPublicService/ListKnowledgeBases",
+        "method": "GET",
+        "timeout": "10s"
+      },
+      {
+        "endpoint": "/artifact.artifact.v1alpha.ArtifactPublicService/UpdateKnowledgeBase",
+        "url_pattern": "/artifact.artifact.v1alpha.ArtifactPublicService/UpdateKnowledgeBase",
+        "method": "PUT",
+        "timeout": "10s"
+      },
+      {
+        "endpoint": "/artifact.artifact.v1alpha.ArtifactPublicService/DeleteKnowledgeBase",
+        "url_pattern": "/artifact.artifact.v1alpha.ArtifactPublicService/DeleteKnowledgeBase",
+        "method": "DELETE",
+        "timeout": "10s"
       }
     ],
     "grpc_no_auth": [

--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -2089,19 +2089,19 @@
       {
         "endpoint": "/artifact.artifact.v1alpha.ArtifactPublicService/ListKnowledgeBases",
         "url_pattern": "/artifact.artifact.v1alpha.ArtifactPublicService/ListKnowledgeBases",
-        "method": "GET",
+        "method": "POST",
         "timeout": "10s"
       },
       {
         "endpoint": "/artifact.artifact.v1alpha.ArtifactPublicService/UpdateKnowledgeBase",
         "url_pattern": "/artifact.artifact.v1alpha.ArtifactPublicService/UpdateKnowledgeBase",
-        "method": "PUT",
+        "method": "POST",
         "timeout": "10s"
       },
       {
         "endpoint": "/artifact.artifact.v1alpha.ArtifactPublicService/DeleteKnowledgeBase",
         "url_pattern": "/artifact.artifact.v1alpha.ArtifactPublicService/DeleteKnowledgeBase",
-        "method": "DELETE",
+        "method": "POST",
         "timeout": "10s"
       }
     ],


### PR DESCRIPTION
Because

- we need to knowledge base crud endpoints in public internet

This commit

- expose the knowledge base crud http endpoints
