### PR TITLE
chore(artifact): fix missing field

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -2073,25 +2073,29 @@
         "endpoint": "/v1alpha/knowledge-base",
         "url_pattern": "/v1alpha/knowledge-base",
         "method": "POST",
-        "timeout": "10s"
+        "timeout": "10s",
+        "input_query_strings": []
       },
       {
         "endpoint": "/v1alpha/users/{uid}/knowledge-base",
         "url_pattern": "/v1alpha/users/{uid}/knowledge-base",
         "method": "GET",
-        "timeout": "10s"
+        "timeout": "10s",
+        "input_query_strings": []
       },
       {
         "endpoint": "/v1alpha/knowledge-base/{id}",
         "url_pattern": "/v1alpha/knowledge-base/{id}",
         "method": "PUT",
-        "timeout": "10s"
+        "timeout": "10s",
+        "input_query_strings": []
       },
       {
         "endpoint": "/v1alpha/knowledge-base/{id}",
         "url_pattern": "/v1alpha/knowledge-base/{id}",
         "method": "DELETE",
-        "timeout": "10s"
+        "timeout": "10s",
+        "input_query_strings": []
       }
     ],
     "grpc_auth": [


### PR DESCRIPTION
Because

- Missing `input_query_strings` for artifact related endpoitns
```
Found error while executing template:template: artifact.tmpl:9:9: executing "artifact.tmpl" at <len .input_query_strings>: error calling len: reflect: call of reflect.Value.Type on zero Value
```

This commit

- add missing `input_query_strings`
