### PR TITLE
chore(model): add endpoints to get latest operation result

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1691,6 +1691,24 @@
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/operation",
+        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/operation",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "view"
+        ]
+      },
+      {
+        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/operation",
+        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/operation",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "view"
+        ]
       }
     ],
     "no_auth": [
@@ -2000,6 +2018,18 @@
         "url_pattern": "/model.model.v1alpha.ModelPublicService/TriggerOrganizationModelBinaryFileUpload",
         "method": "POST",
         "timeout": "600s"
+      },
+      {
+        "endpoint": "/model.model.v1alpha.ModelPublicService/GetUserLatestModelOperation",
+        "url_pattern": "/model.model.v1alpha.ModelPublicService/GetUserLatestModelOperation",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/model.model.v1alpha.ModelPublicService/GetOrganizationLatestModelOperation",
+        "url_pattern": "/model.model.v1alpha.ModelPublicService/GetOrganizationLatestModelOperation",
+        "method": "POST",
+        "timeout": "5s"
       },
       {
         "endpoint": "/model.model.v1alpha.ModelPublicService/GetModelOperation",


### PR DESCRIPTION
Because

- Model overview page needs to retrieve input and output data from latest model async trigger

This commit

- add endpoints to get latest operation result
