### PR TITLE
chore(registry): adopt org model deployment endpoint

### DIFF
--- a/plugins/grpc-proxy/go.sum
+++ b/plugins/grpc-proxy/go.sum
@@ -7,6 +7,8 @@ github.com/go-chi/chi v4.0.1+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxm
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba h1:EJd2eHk3H+nXcSxHjvjeWRaJ5EhMOP/8ZcfuM9wE2T4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/luraproject/lura v1.4.1 h1:zNzLYMzM13EaSrb9bfaPICD4bXtNqMCdyi42R1eBgro=
 github.com/luraproject/lura v1.4.1/go.mod h1:KIo1/+nsRZVxIO04Hkbth0GXSSzypvkFpF5KaIoLvlo=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=

--- a/plugins/multi-auth/go.mod
+++ b/plugins/multi-auth/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/gofrs/uuid v4.3.1+incompatible
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba
 	github.com/luraproject/lura v1.4.1
 	google.golang.org/grpc v1.63.2
 )

--- a/plugins/multi-auth/go.sum
+++ b/plugins/multi-auth/go.sum
@@ -15,6 +15,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0Q
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a h1:k4tq5qQQABKiQ7uuEN2K54jnx3eVaW/PQpZXBU/SGdQ=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba h1:EJd2eHk3H+nXcSxHjvjeWRaJ5EhMOP/8ZcfuM9wE2T4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/luraproject/lura v1.4.1 h1:zNzLYMzM13EaSrb9bfaPICD4bXtNqMCdyi42R1eBgro=
 github.com/luraproject/lura v1.4.1/go.mod h1:KIo1/+nsRZVxIO04Hkbth0GXSSzypvkFpF5KaIoLvlo=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=

--- a/plugins/registry/go.mod
+++ b/plugins/registry/go.mod
@@ -5,7 +5,7 @@ go 1.22.2
 require (
 	github.com/distribution/distribution v2.8.3+incompatible
 	github.com/frankban/quicktest v1.14.6
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba
 	github.com/luraproject/lura v1.4.1
 	google.golang.org/grpc v1.63.2
 )

--- a/plugins/registry/go.sum
+++ b/plugins/registry/go.sum
@@ -21,6 +21,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0Q
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a h1:k4tq5qQQABKiQ7uuEN2K54jnx3eVaW/PQpZXBU/SGdQ=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba h1:EJd2eHk3H+nXcSxHjvjeWRaJ5EhMOP/8ZcfuM9wE2T4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/plugins/registry/handler.go
+++ b/plugins/registry/handler.go
@@ -300,19 +300,30 @@ func (rh *registryHandler) relay(ctx context.Context, p registryHandlerParams) {
 		// is publishing the push operation success as an event and let the
 		// clients to consume and act upon it (artifact to register the tag
 		// creation time, model to deploy the image...).
-		prefix := "users"
 		if isOrganizationRepository {
-			prefix = "organizations"
-		}
-		deployReq := &modelpb.DeployModelAdminRequest{
-			Name:    fmt.Sprintf("%s/%s/models/%s", prefix, namespace, contentID),
-			Version: resourceID,
-			Digest:  digest,
-		}
-		if _, err := rh.modelPrivateClient.DeployModelAdmin(ctx, deployReq); err != nil {
-			logger.Error(req.URL.Path, "failed to deploy model", err)
-			rh.handleError(req, w, err)
-			return
+			prefix := "organizations"
+			deployReq := &modelpb.DeployOrganizationModelAdminRequest{
+				Name:    fmt.Sprintf("%s/%s/models/%s", prefix, namespace, contentID),
+				Version: resourceID,
+				Digest:  digest,
+			}
+			if _, err := rh.modelPrivateClient.DeployOrganizationModelAdmin(ctx, deployReq); err != nil {
+				logger.Error(req.URL.Path, "failed to deploy organization model", err)
+				rh.handleError(req, w, err)
+				return
+			}
+		} else {
+			prefix := "users"
+			deployReq := &modelpb.DeployUserModelAdminRequest{
+				Name:    fmt.Sprintf("%s/%s/models/%s", prefix, namespace, contentID),
+				Version: resourceID,
+				Digest:  digest,
+			}
+			if _, err := rh.modelPrivateClient.DeployUserModelAdmin(ctx, deployReq); err != nil {
+				logger.Error(req.URL.Path, "failed to deploy user model", err)
+				rh.handleError(req, w, err)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Because

- we are missing org deployment flow in registry plugin

This commit

- adopt org model deployment endpoint
