### PR TITLE
feat(pipeline): add requester UID header

### DIFF
--- a/config/share/settings-env/input_headers.json
+++ b/config/share/settings-env/input_headers.json
@@ -26,7 +26,8 @@
     "Instill-User-Id",
     "Instill-Visitor-Uid",
     "Instill-Return-Traces",
-    "Instill-Share-Code"
+    "Instill-Share-Code",
+    "Instill-Requester-Uid"
   ],
   "no_auth": [
     "Content-Type",
@@ -56,7 +57,8 @@
     "Instill-User-Id",
     "Instill-Visitor-Uid",
     "Instill-Return-Traces",
-    "Instill-Share-Code"
+    "Instill-Share-Code",
+    "Instill-Requester-Uid"
   ],
   "grpc_no_auth": [
     "Content-Type",


### PR DESCRIPTION
Because

- In order to trigger pipelines after switching namespaces, API must identify
  the requester on behalf of whom the action is performed.

This commit

- Adds the requester UID header to the accepted headers.
