### PR TITLE
feat(pipeline): add requester header to CORS

### DIFF
--- a/config/share/templates/cors.tmpl
+++ b/config/share/templates/cors.tmpl
@@ -27,7 +27,8 @@
     "X-B3-Traceid",
     "Access-Control-Allow-Headers",
     "Instill-Return-Traces",
-    "Instill-Share-Code"
+    "Instill-Share-Code",
+    "Instill-Requester-Uid"
   ],
   "allow_credentials": false,
   "debug": false


### PR DESCRIPTION
Because

- `pipeline-backend` will parse the `Instill-Requester-Uid` header and transform
  it to a system variable that will be passed to the pipeline trigger workers.

This commit

- Adds the header to the CORS configuration.
