### PR TITLE
feat(cors): allow Instill-Use-SSE header

### DIFF
--- a/config/share/templates/cors.tmpl
+++ b/config/share/templates/cors.tmpl
@@ -28,7 +28,8 @@
     "Access-Control-Allow-Headers",
     "Instill-Return-Traces",
     "Instill-Share-Code",
-    "Instill-Requester-Uid"
+    "Instill-Requester-Uid",
+    "Instill-Use-SSE"
   ],
   "allow_credentials": false,
   "debug": false


### PR DESCRIPTION
Because

- We need to allow the `Instill-Use-SSE` header in the CORS allow list.

This commit

- allows the `Instill-Use-SSE` header.