### PR TITLE
feat(vdp): expose pipeline profile image endpoint

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -982,6 +982,20 @@
         "method": "GET",
         "timeout": "5s",
         "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/users/{user_id}/pipelines/{pipeline_id}/image",
+        "url_pattern": "/v1beta/users/{user_id}/pipelines/{pipeline_id}/image",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/organizations/{organization_id}/pipelines/{pipeline_id}/image",
+        "url_pattern": "/v1beta/organizations/{organization_id}/pipelines/{pipeline_id}/image",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": []
       }
     ],
     "grpc_auth": [


### PR DESCRIPTION
Because

- We'll allow users to store pipeline `profile image`.

This commit

- Exposes pipeline profile image endpoint.