### PR TITLE
feat(registry): adopt namespace endpoint

### DIFF
--- a/plugins/multi-auth/go.mod
+++ b/plugins/multi-auth/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/gofrs/uuid v4.3.1+incompatible
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725184849-7098e99ffbb1
 	github.com/luraproject/lura v1.4.1
 	google.golang.org/grpc v1.63.2
 )

--- a/plugins/multi-auth/go.sum
+++ b/plugins/multi-auth/go.sum
@@ -17,6 +17,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba h1:EJd2eHk3H+nXcSxHjvjeWRaJ5EhMOP/8ZcfuM9wE2T4=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725184849-7098e99ffbb1 h1:pmuTg0xaE55jZG50bTS40LfbL+d4NtmX2WiSfX269gk=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725184849-7098e99ffbb1/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/luraproject/lura v1.4.1 h1:zNzLYMzM13EaSrb9bfaPICD4bXtNqMCdyi42R1eBgro=
 github.com/luraproject/lura v1.4.1/go.mod h1:KIo1/+nsRZVxIO04Hkbth0GXSSzypvkFpF5KaIoLvlo=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=

--- a/plugins/registry/go.mod
+++ b/plugins/registry/go.mod
@@ -5,7 +5,7 @@ go 1.22.2
 require (
 	github.com/distribution/distribution v2.8.3+incompatible
 	github.com/frankban/quicktest v1.14.6
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725184849-7098e99ffbb1
 	github.com/luraproject/lura v1.4.1
 	google.golang.org/grpc v1.63.2
 )

--- a/plugins/registry/go.sum
+++ b/plugins/registry/go.sum
@@ -23,6 +23,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240327112131-e593145f363a/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba h1:EJd2eHk3H+nXcSxHjvjeWRaJ5EhMOP/8ZcfuM9wE2T4=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725184849-7098e99ffbb1 h1:pmuTg0xaE55jZG50bTS40LfbL+d4NtmX2WiSfX269gk=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725184849-7098e99ffbb1/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
Because

- Previously, we used a general name parameter in request parameters, e.g., {name=users/*}, which was ambiguous.

This commit

- use explicit user_id in request
- adopt namespace endpoints
