### PR TITLE
fix(mgmt): restore pipeline dashboard enpoints

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -207,11 +207,18 @@
         "input_query_strings": ["namespaceId", "start", "stop"]
       },
       {
+        "endpoint": "/v1beta/metrics/vdp/pipeline/tables",
+        "url_pattern": "/v1beta/metrics/vdp/pipeline/tables",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": ["pageSize", "pageToken", "filter"]
+      },
+      {
         "endpoint": "/v1beta/metrics/vdp/pipeline/charts",
         "url_pattern": "/v1beta/metrics/vdp/pipeline/charts",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["namespaceId", "aggregationWindow", "start", "stop"]
+        "input_query_strings": ["aggregationWindow", "filter"]
       }
     ],
     "no_auth": [
@@ -381,6 +388,12 @@
       {
         "endpoint": "/core.mgmt.v1beta.MgmtPublicService/GetPipelineTriggerCount",
         "url_pattern": "/core.mgmt.v1beta.MgmtPublicService/GetPipelineTriggerCount",
+        "method": "POST",
+        "timeout": "30s"
+      },
+      {
+        "endpoint": "/core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords",
+        "url_pattern": "/core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords",
         "method": "POST",
         "timeout": "30s"
       },


### PR DESCRIPTION
Because

- The new dashboard endpoints introduced breaking changes and the clients won't be ready for the upcoming release.

This commit

- Restores the previous dashboard endpoints
  - `ListPipelineTriggerRecords` isn't added back as it had no clients.
