### PR TITLE
fix(registry): fix wrong namespace format comparison

### DIFF
--- a/plugins/registry/handler.go
+++ b/plugins/registry/handler.go
@@ -217,7 +217,7 @@ func (rh *registryHandler) relay(ctx context.Context, p registryHandlerParams) {
 
 		isValid := false
 		for _, membership := range resp.Memberships {
-			if namespace == membership.Organization.Name && membership.State == mgmtpb.MembershipState_MEMBERSHIP_STATE_ACTIVE {
+			if namespace == membership.Organization.Id && membership.State == mgmtpb.MembershipState_MEMBERSHIP_STATE_ACTIVE {
 				isValid = true
 				break
 			}


### PR DESCRIPTION
Because

- Comparing `Organization.Name` with formant `organizations/{id}` to `namespace` with format `{id}` will always result in false, causing organization model not able to be pushed.

This commit

- fix wrong namespace format comparison
