### PR TITLE
feat(model): added model run logging endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ krakend.json
 # air related files and folders
 .air.toml
 tmp
+.idea

--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1913,6 +1913,19 @@
         "input_query_strings": []
       },
       {
+        "endpoint": "/v1beta/namespaces/{namespace_id}/models/{model_id}/runs",
+        "url_pattern": "/v1beta/namespaces/{namespace_id}/models/{model_id}/runs",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "view",
+          "pageSize",
+          "pageToken",
+          "filter",
+          "orderBy"
+        ]
+      },
+      {
         "endpoint": "/v1alpha/users/{user_id}/models",
         "url_pattern": "/v1alpha/users/{user_id}/models",
         "method": "GET",


### PR DESCRIPTION
Because

- FE needs to access model run logging endpoint

This commit

- added model run logging endpoint
