### PR TITLE
feat(model): fixed model run logging endpoint prefix

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1913,8 +1913,8 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/namespaces/{namespace_id}/models/{model_id}/runs",
-        "url_pattern": "/v1beta/namespaces/{namespace_id}/models/{model_id}/runs",
+        "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/runs",
+        "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/runs",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [


### PR DESCRIPTION
Because

- model backend point prefix should be v1alpha

This commit

- fixed model backend point prefix
