### PR TITLE
feat(mgmt): use unified dashboard endpoints

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -97,7 +97,9 @@ jobs:
       - name: Install k6
         run: |
           go install go.k6.io/xk6/cmd/xk6@v${{ env.XK6_VERSION }}
-          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
+          xk6 build v${{ env.K6_VERSION }} \
+            --with github.com/grafana/xk6-sql@v${{ env.XK6_SQL_VERSION }} \
+            --with github.com/grafana/xk6-sql-driver-postgres@v${{ env.XK6_SQL_POSTGRES_VERSION }} && sudo cp k6 /usr/bin
 
       - name: Run ${{ matrix.component }} integration test (latest)
         run: |

--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -208,12 +208,12 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1beta/metrics/vdp/pipeline/trigger-count",
-        "url_pattern": "/v1beta/metrics/vdp/pipeline/trigger-count",
+        "endpoint": "/v1beta/pipeline-runs/count",
+        "url_pattern": "/v1beta/pipeline-runs/count",
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": [
-          "namespaceId",
+          "requesterId",
           "start",
           "stop"
         ]

--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -251,6 +251,18 @@
         ]
       },
       {
+        "endpoint": "/v1beta/pipeline-runs/query-charts",
+        "url_pattern": "/v1beta/pipeline-runs/query-charts",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "requesterId",
+          "aggregationWindow",
+          "start",
+          "stop"
+        ]
+      },
+      {
         "endpoint": "/v1beta/model-runs/count",
         "url_pattern": "/v1beta/model-runs/count",
         "method": "GET",
@@ -447,6 +459,12 @@
       {
         "endpoint": "/core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords",
         "url_pattern": "/core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords",
+        "method": "POST",
+        "timeout": "30s"
+      },
+      {
+        "endpoint": "/core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerChartRecordsV0",
+        "url_pattern": "/core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerChartRecordsV0",
         "method": "POST",
         "timeout": "30s"
       },


### PR DESCRIPTION
Because

- Pipeline and credit endpoints have different params and schemas.
- Some of the information served by the existing endpoints will be handled by the pipeline run feature.

This commit

- Applies contracts defined in
https://github.com/instill-ai/protobufs/pull/435