### PR TITLE
chore(vdp,model): add Instill-User-Agent into header list

### DIFF
--- a/config/share/settings-env/input_headers.json
+++ b/config/share/settings-env/input_headers.json
@@ -29,6 +29,7 @@
     "Instill-Share-Code",
     "Instill-Requester-Uid",
     "Instill-Share-Code",
+    "Instill-User-Agent",
     "Instill-Use-SSE"
   ],
   "webhook": [

--- a/config/share/templates/cors.tmpl
+++ b/config/share/templates/cors.tmpl
@@ -29,6 +29,7 @@
     "Instill-Return-Traces",
     "Instill-Share-Code",
     "Instill-Requester-Uid",
+    "Instill-User-Agent",
     "Instill-Use-SSE"
   ],
   "allow_credentials": false,


### PR DESCRIPTION
Because

- The `Instill-User-Agent` header need to be added to the header allow-list.

This commit

- Adds `Instill-User-Agent` into header list.
