### PR TITLE
chore(model): add operation endpoint and remove unused endpoints

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -17,7 +17,9 @@
           "auth/signer": {
             "alg": "RS256",
             "jwk_local_path": "/instill/instill.jwks",
-            "keys_to_sign": ["accessToken"],
+            "keys_to_sign": [
+              "accessToken"
+            ],
             "kid": "instill",
             "disable_jwk_security": true
           }
@@ -120,7 +122,10 @@
         "url_pattern": "/v1beta/organizations",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "pageToken"]
+        "input_query_strings": [
+          "pageSize",
+          "pageToken"
+        ]
       },
       {
         "endpoint": "/v1beta/organizations/{organization_id}",
@@ -183,7 +188,10 @@
         "url_pattern": "/v1beta/tokens",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "pageToken"]
+        "input_query_strings": [
+          "pageSize",
+          "pageToken"
+        ]
       },
       {
         "endpoint": "/v1beta/tokens/{token_id}",
@@ -204,21 +212,32 @@
         "url_pattern": "/v1beta/metrics/vdp/pipeline/trigger-count",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["namespaceId", "start", "stop"]
+        "input_query_strings": [
+          "namespaceId",
+          "start",
+          "stop"
+        ]
       },
       {
         "endpoint": "/v1beta/metrics/vdp/pipeline/tables",
         "url_pattern": "/v1beta/metrics/vdp/pipeline/tables",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "pageToken", "filter"]
+        "input_query_strings": [
+          "pageSize",
+          "pageToken",
+          "filter"
+        ]
       },
       {
         "endpoint": "/v1beta/metrics/vdp/pipeline/charts",
         "url_pattern": "/v1beta/metrics/vdp/pipeline/charts",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["aggregationWindow", "filter"]
+        "input_query_strings": [
+          "aggregationWindow",
+          "filter"
+        ]
       }
     ],
     "no_auth": [
@@ -454,7 +473,9 @@
         "url_pattern": "/v1beta/pipelines/{pipeline_id}/lookUp",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1beta/namespaces/{namespace_id}/pipelines",
@@ -483,7 +504,9 @@
         "url_pattern": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}",
@@ -546,7 +569,12 @@
         "url_pattern": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view", "pageSize", "pageToken", "filter"]
+        "input_query_strings": [
+          "view",
+          "pageSize",
+          "pageToken",
+          "filter"
+        ]
       },
       {
         "endpoint": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases",
@@ -560,7 +588,9 @@
         "url_pattern": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}",
@@ -637,7 +667,11 @@
         "url_pattern": "/v1beta/namespaces/{namespace_id}/secrets",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "pageToken", "filter"]
+        "input_query_strings": [
+          "pageSize",
+          "pageToken",
+          "filter"
+        ]
       },
       {
         "endpoint": "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}",
@@ -687,7 +721,9 @@
         "url_pattern": "/v1beta/users/{user_id}/pipelines/{pipeline_id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1beta/users/{user_id}/pipelines/{pipeline_id}",
@@ -750,7 +786,12 @@
         "url_pattern": "/v1beta/users/{user_id}/pipelines/{pipeline_id}/releases",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view", "pageSize", "pageToken", "filter"]
+        "input_query_strings": [
+          "view",
+          "pageSize",
+          "pageToken",
+          "filter"
+        ]
       },
       {
         "endpoint": "/v1beta/users/{user_id}/pipelines/{pipeline_id}/releases",
@@ -764,7 +805,9 @@
         "url_pattern": "/v1beta/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1beta/users/{user_id}/pipelines/{pipeline_id}/releases/{release_id}",
@@ -856,7 +899,9 @@
         "url_pattern": "/v1beta/organizations/{organization_id}/pipelines/{pipeline_id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1beta/organizations/{organization_id}/pipelines/{pipeline_id}",
@@ -919,7 +964,12 @@
         "url_pattern": "/v1beta/organizations/{organization_id}/pipelines/{pipeline_id}/releases",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view", "pageSize", "pageToken", "filter"]
+        "input_query_strings": [
+          "view",
+          "pageSize",
+          "pageToken",
+          "filter"
+        ]
       },
       {
         "endpoint": "/v1beta/organizations/{organization_id}/pipelines/{pipeline_id}/releases",
@@ -933,7 +983,9 @@
         "url_pattern": "/v1beta/organizations/{organization_id}/pipelines/{pipeline_id}/releases/{release_id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1beta/organizations/{organization_id}/pipelines/{pipeline_id}/releases/{release_id}",
@@ -1017,7 +1069,11 @@
         "url_pattern": "/v1beta/users/{user_id}/secrets",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "pageToken", "filter"]
+        "input_query_strings": [
+          "pageSize",
+          "pageToken",
+          "filter"
+        ]
       },
       {
         "endpoint": "/v1beta/users/{user_id}/secrets/{secret_id}",
@@ -1052,7 +1108,11 @@
         "url_pattern": "/v1beta/organizations/{organization_id}/secrets",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "pageToken", "filter"]
+        "input_query_strings": [
+          "pageSize",
+          "pageToken",
+          "filter"
+        ]
       },
       {
         "endpoint": "/v1beta/organizations/{organization_id}/secrets/{secret_id}",
@@ -1080,7 +1140,12 @@
         "url_pattern": "/v1beta/component-definitions",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "page", "view", "filter"]
+        "input_query_strings": [
+          "pageSize",
+          "page",
+          "view",
+          "filter"
+        ]
       },
       {
         "endpoint": "/v1beta/operator-definitions",
@@ -1100,7 +1165,9 @@
         "url_pattern": "/v1beta/operator-definitions/{id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1beta/connector-definitions",
@@ -1120,7 +1187,9 @@
         "url_pattern": "/v1beta/connector-definitions/{id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/runs",
@@ -1185,14 +1254,20 @@
         "url_pattern": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/events",
         "method": "POST",
         "timeout": "600s",
-        "input_query_strings": ["event", "code"]
+        "input_query_strings": [
+          "event",
+          "code"
+        ]
       },
       {
         "endpoint": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/events",
         "url_pattern": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/events",
         "method": "POST",
         "timeout": "600s",
-        "input_query_strings": ["event", "code"]
+        "input_query_strings": [
+          "event",
+          "code"
+        ]
       }
     ],
     "grpc_auth": [
@@ -1774,7 +1849,9 @@
         "url_pattern": "/v1alpha/models/{model_id}/lookUp",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1alpha/namespaces/{namespace_id}/models",
@@ -1799,18 +1876,13 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/namespaces/{namespace_id}/models/multipart",
-        "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/multipart",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
         "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}",
         "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}",
@@ -1834,44 +1906,9 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/publish",
-        "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/publish",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/unpublish",
-        "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/unpublish",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/readme",
-        "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/readme",
-        "method": "GET",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
         "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/watch",
         "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/watch",
         "method": "GET",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/deploy",
-        "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/deploy",
-        "method": "POST",
-        "timeout": "86400s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/undeploy",
-        "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/undeploy",
-        "method": "POST",
         "timeout": "30s",
         "input_query_strings": []
       },
@@ -1901,7 +1938,10 @@
         "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "page"]
+        "input_query_strings": [
+          "pageSize",
+          "page"
+        ]
       },
       {
         "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions/{version_id}",
@@ -1974,18 +2014,13 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/users/{user_id}/models/multipart",
-        "url_pattern": "/v1alpha/users/{user_id}/models/multipart",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
         "endpoint": "/v1alpha/users/{user_id}/models/{model_id}",
         "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1alpha/users/{user_id}/models/{model_id}",
@@ -2009,44 +2044,9 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/publish",
-        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/publish",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/unpublish",
-        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/unpublish",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/readme",
-        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/readme",
-        "method": "GET",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
         "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/watch",
         "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/watch",
         "method": "GET",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/deploy",
-        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/deploy",
-        "method": "POST",
-        "timeout": "86400s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/undeploy",
-        "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/undeploy",
-        "method": "POST",
         "timeout": "30s",
         "input_query_strings": []
       },
@@ -2076,7 +2076,10 @@
         "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/versions",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "page"]
+        "input_query_strings": [
+          "pageSize",
+          "page"
+        ]
       },
       {
         "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/versions/{version_id}",
@@ -2136,18 +2139,13 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/organizations/{organization_id}/models/multipart",
-        "url_pattern": "/v1alpha/organizations/{organization_id}/models/multipart",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
         "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}",
         "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}",
@@ -2171,44 +2169,9 @@
         "input_query_strings": []
       },
       {
-        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/publish",
-        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/publish",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/unpublish",
-        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/unpublish",
-        "method": "POST",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/readme",
-        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/readme",
-        "method": "GET",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
         "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/watch",
         "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/watch",
         "method": "GET",
-        "timeout": "30s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/deploy",
-        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/deploy",
-        "method": "POST",
-        "timeout": "86400s",
-        "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/undeploy",
-        "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/undeploy",
-        "method": "POST",
         "timeout": "30s",
         "input_query_strings": []
       },
@@ -2238,7 +2201,10 @@
         "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/versions",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "page"]
+        "input_query_strings": [
+          "pageSize",
+          "page"
+        ]
       },
       {
         "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/versions/{version_id}",
@@ -2283,25 +2249,40 @@
         "input_query_strings": []
       },
       {
+        "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions/{version_id}/operation",
+        "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions/{version_id}/operation",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "view"
+        ]
+      },
+      {
         "endpoint": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/operation",
         "url_pattern": "/v1alpha/namespaces/{namespace_id}/models/{model_id}/operation",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1alpha/users/{user_id}/models/{model_id}/operation",
         "url_pattern": "/v1alpha/users/{user_id}/models/{model_id}/operation",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       },
       {
         "endpoint": "/v1alpha/organizations/{organization_id}/models/{model_id}/operation",
         "url_pattern": "/v1alpha/organizations/{organization_id}/models/{model_id}/operation",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view"]
+        "input_query_strings": [
+          "view"
+        ]
       }
     ],
     "no_auth": [
@@ -2331,7 +2312,11 @@
         "url_pattern": "/v1alpha/model-definitions",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["view", "pageSize", "pageToken"]
+        "input_query_strings": [
+          "view",
+          "pageSize",
+          "pageToken"
+        ]
       },
       {
         "endpoint": "/v1alpha/model-definitions/{definition_name}",
@@ -2382,12 +2367,6 @@
         "timeout": "5s"
       },
       {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/CreateNamespaceModelBinaryFileUpload",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/CreateNamespaceModelBinaryFileUpload",
-        "method": "POST",
-        "timeout": "86400s"
-      },
-      {
         "endpoint": "/model.model.v1alpha.ModelPublicService/ListNamespaceModels",
         "url_pattern": "/model.model.v1alpha.ModelPublicService/ListNamespaceModels",
         "method": "POST",
@@ -2426,30 +2405,6 @@
       {
         "endpoint": "/model.model.v1alpha.ModelPublicService/RenameNamespaceModel",
         "url_pattern": "/model.model.v1alpha.ModelPublicService/RenameNamespaceModel",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/PublishNamespaceModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/PublishNamespaceModel",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/UnpublishNamespaceModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/UnpublishNamespaceModel",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/DeployNamespaceModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/DeployNamespaceModel",
-        "method": "POST",
-        "timeout": "86400s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/UndeployNamespaceModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/UndeployNamespaceModel",
         "method": "POST",
         "timeout": "5s"
       },
@@ -2508,12 +2463,6 @@
         "timeout": "5s"
       },
       {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/CreateUserModelBinaryFileUpload",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/CreateUserModelBinaryFileUpload",
-        "method": "POST",
-        "timeout": "86400s"
-      },
-      {
         "endpoint": "/model.model.v1alpha.ModelPublicService/ListUserModels",
         "url_pattern": "/model.model.v1alpha.ModelPublicService/ListUserModels",
         "method": "POST",
@@ -2552,30 +2501,6 @@
       {
         "endpoint": "/model.model.v1alpha.ModelPublicService/RenameUserModel",
         "url_pattern": "/model.model.v1alpha.ModelPublicService/RenameUserModel",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/PublishUserModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/PublishUserModel",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/UnpublishUserModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/UnpublishUserModel",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/DeployUserModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/DeployUserModel",
-        "method": "POST",
-        "timeout": "86400s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/UndeployUserModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/UndeployUserModel",
         "method": "POST",
         "timeout": "5s"
       },
@@ -2634,12 +2559,6 @@
         "timeout": "5s"
       },
       {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/CreateOrganizationModelBinaryFileUpload",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/CreateOrganizationModelBinaryFileUpload",
-        "method": "POST",
-        "timeout": "86400s"
-      },
-      {
         "endpoint": "/model.model.v1alpha.ModelPublicService/ListOrganizationModels",
         "url_pattern": "/model.model.v1alpha.ModelPublicService/ListOrganizationModels",
         "method": "POST",
@@ -2678,30 +2597,6 @@
       {
         "endpoint": "/model.model.v1alpha.ModelPublicService/RenameOrganizationModel",
         "url_pattern": "/model.model.v1alpha.ModelPublicService/RenameOrganizationModel",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/PublishOrganizationModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/PublishOrganizationModel",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/UnpublishOrganizationModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/UnpublishOrganizationModel",
-        "method": "POST",
-        "timeout": "5s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/DeployOrganizationModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/DeployOrganizationModel",
-        "method": "POST",
-        "timeout": "86400s"
-      },
-      {
-        "endpoint": "/model.model.v1alpha.ModelPublicService/UndeployOrganizationModel",
-        "url_pattern": "/model.model.v1alpha.ModelPublicService/UndeployOrganizationModel",
         "method": "POST",
         "timeout": "5s"
       },
@@ -2778,6 +2673,12 @@
         "timeout": "5s"
       },
       {
+        "endpoint": "/model.model.v1alpha.ModelPublicService/GetNamespaceModelOperation",
+        "url_pattern": "/model.model.v1alpha.ModelPublicService/GetNamespaceModelOperation",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
         "endpoint": "/model.model.v1alpha.ModelPublicService/ListModelRuns",
         "url_pattern": "/model.model.v1alpha.ModelPublicService/ListModelRuns",
         "method": "POST",
@@ -2840,7 +2741,10 @@
         "url_pattern": "/v1alpha/repositories/{namespace}/{id}/tags",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "page"]
+        "input_query_strings": [
+          "pageSize",
+          "page"
+        ]
       },
       {
         "endpoint": "/v1alpha/namespaces/{namespace_id}/catalogs",
@@ -2882,14 +2786,20 @@
         "url_pattern": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files",
         "method": "GET",
         "timeout": "10s",
-        "input_query_strings": ["pageSize", "pageToken", "filter.fileUids"]
+        "input_query_strings": [
+          "pageSize",
+          "pageToken",
+          "filter.fileUids"
+        ]
       },
       {
         "endpoint": "/v1alpha/catalogs/files",
         "url_pattern": "/v1alpha/catalogs/files",
         "method": "DELETE",
         "timeout": "10s",
-        "input_query_strings": ["fileUid"]
+        "input_query_strings": [
+          "fileUid"
+        ]
       },
       {
         "endpoint": "/v1alpha/catalogs/files/processAsync",
@@ -2903,7 +2813,9 @@
         "url_pattern": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/chunks",
         "method": "GET",
         "timeout": "10s",
-        "input_query_strings": ["fileUid"]
+        "input_query_strings": [
+          "fileUid"
+        ]
       },
       {
         "endpoint": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files/{file_uid}/source",
@@ -2938,7 +2850,10 @@
         "url_pattern": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["fileId", "fileUid"]
+        "input_query_strings": [
+          "fileId",
+          "fileUid"
+        ]
       },
       {
         "endpoint": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/conversations",
@@ -2952,7 +2867,10 @@
         "url_pattern": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/conversations",
         "method": "GET",
         "timeout": "30s",
-        "input_query_strings": ["pageSize", "pageToken"]
+        "input_query_strings": [
+          "pageSize",
+          "pageToken"
+        ]
       },
       {
         "endpoint": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/conversations/{conversation_id}",


### PR DESCRIPTION
Because

- Some instill model's endpoints are deprecated
- add endpoint for getting namespace model operation with particular version

This commit

- add operation endpoint and remove unused endpoints
