### PR TITLE
feat(vdp): use the `Accept` header to identify and handle `text/event-stream`

### DIFF
--- a/config/share/settings-env/input_headers.json
+++ b/config/share/settings-env/input_headers.json
@@ -11,6 +11,7 @@
     "X-B3-Traceid"
   ],
   "http_auth": [
+    "Accept",
     "Authorization",
     "Content-Type",
     "Content-Length",
@@ -29,8 +30,7 @@
     "Instill-Share-Code",
     "Instill-Requester-Uid",
     "Instill-Share-Code",
-    "Instill-User-Agent",
-    "Instill-Use-SSE"
+    "Instill-User-Agent"
   ],
   "webhook": [
     "*"

--- a/config/share/templates/cors.tmpl
+++ b/config/share/templates/cors.tmpl
@@ -17,6 +17,7 @@
   ],
   "max_age": "12h",
   "allow_headers": [
+    "Accept",
     "Accept-Language",
     "Origin",
     "Content-Length",
@@ -29,8 +30,7 @@
     "Instill-Return-Traces",
     "Instill-Share-Code",
     "Instill-Requester-Uid",
-    "Instill-User-Agent",
-    "Instill-Use-SSE"
+    "Instill-User-Agent"
   ],
   "allow_credentials": false,
   "debug": false

--- a/plugins/grpc-proxy/server.go
+++ b/plugins/grpc-proxy/server.go
@@ -81,7 +81,7 @@ func (r registerer) RegisterHandlers(f func(
 func (r registerer) registerHandlers(ctx context.Context, extra map[string]interface{}, h http.Handler) (http.Handler, error) {
 
 	return h2c.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.Header.Get("instill-use-sse") == "true" {
+		if req.Header.Get("Accept") == "text/event-stream" {
 			// For SSE, we need to skip this plugin.
 			h.ServeHTTP(w, req)
 		} else {

--- a/plugins/multi-auth/main.go
+++ b/plugins/multi-auth/main.go
@@ -107,7 +107,7 @@ func (r registerer) registerHandlers(ctx context.Context, extra map[string]inter
 			req.Header.Set("Instill-Visitor-Uid", visitorID.String())
 			h.ServeHTTP(w, req)
 
-		} else if req.Header.Get("instill-use-sse") == "true" {
+		} else if req.Header.Get("Accept") == "text/event-stream" {
 			// Currently, KrakenD doesn’t support event-stream. To make
 			// authentication work, we send a request to the management API
 			// first for verification.
@@ -117,7 +117,7 @@ func (r registerer) registerHandlers(ctx context.Context, extra map[string]inter
 				return
 			}
 			r.Header = req.Header
-			r.Header.Del("instill-use-sse")
+			r.Header["Accept"][0] = "*/*"
 
 			resp, err := httpClient.Do(r)
 			if err != nil {
@@ -149,7 +149,7 @@ func (r registerer) registerHandlers(ctx context.Context, extra map[string]inter
 
 			req.Header.Set("Instill-Auth-Type", "user")
 			req.Header.Set("Instill-User-Uid", u.User.UID)
-			req.Header.Set("instill-Use-SSE", "true")
+			req.Header.Set("Accept", "text/event-stream")
 			h.ServeHTTP(w, req)
 
 		} else {

--- a/plugins/sse-streaming/main.go
+++ b/plugins/sse-streaming/main.go
@@ -73,7 +73,7 @@ func (r registerer) registerHandlers(ctx context.Context, extra map[string]inter
 		httpClient := http.Client{Transport: http.DefaultTransport}
 
 		// This is a quick solution since we only support sse for pipeline trigger endpoint
-		if req.Header.Get("instill-use-sse") == "true" {
+		if req.Header.Get("Accept") == "text/event-stream" {
 			proxyHandler(w, req, httpClient, backendHost)
 		} else {
 			h.ServeHTTP(w, req)


### PR DESCRIPTION
Because

- We should use the common `Accept` header to determine the response content type as `text/event-stream`.

This commit

- Uses the `Accept` header to identify and handle `text/event-stream`.
