### PR TITLE
feat(pipeline): add connection create and get endpoints

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1234,6 +1234,20 @@
         "method": "GET",
         "timeout": "30s",
         "input_query_strings": ["view"]
+      },
+      {
+        "endpoint": "/v1beta/namespaces/{namespace_id}/connections",
+        "url_pattern": "/v1beta/namespaces/{namespace_id}/connections",
+        "method": "POST",
+        "timeout": "30s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1beta/namespaces/{namespace_id}/connections/{connection_id}",
+        "url_pattern": "/v1beta/namespaces/{namespace_id}/connections/{connection_id}",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": ["view"]
       }
     ],
     "no_auth": [
@@ -1838,6 +1852,18 @@
       {
         "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/ListIntegrations",
         "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/ListIntegrations",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/CreateNamespaceConnection",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/CreateNamespaceConnection",
+        "method": "POST",
+        "timeout": "5s"
+      },
+      {
+        "endpoint": "/vdp.pipeline.v1beta.ConnectionPublicService/GetNamespaceConnection",
+        "url_pattern": "/vdp.pipeline.v1beta.ConnectionPublicService/GetNamespaceConnection",
         "method": "POST",
         "timeout": "5s"
       }


### PR DESCRIPTION
Because

- With the integration endpoints, users can fetch the schemas to create connection resources.

This commit

- Opens the creation and view endpoints for connections.
