### PR TITLE
chore(test): add xk6 to integration test action

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -87,9 +87,14 @@ jobs:
           EDITION=local-ce:test \
           docker compose -f docker-compose.yml -f docker-compose-latest.yml rm -f
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+
       - name: Install k6
         run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
+          go install go.k6.io/xk6/cmd/xk6@v${{ env.XK6_VERSION }}
+          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
 
       - name: Run ${{ matrix.component }} integration test (latest)
         run: |


### PR DESCRIPTION
Because

- Integration tests use `xk6` to run a SQL plugin.

This commit

- Update GitHub action to install `xk6` SQL plugin.
