### PR TITLE
fix(connection): fix GetNamespaceConnection route

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1935,8 +1935,8 @@
         "timeout": "5s"
       },
       {
-        "endpoint": "/vdp.pipeline.v1beta.ConnectionPublicService/GetNamespaceConnection",
-        "url_pattern": "/vdp.pipeline.v1beta.ConnectionPublicService/GetNamespaceConnection",
+        "endpoint": "/vdp.pipeline.v1beta.PipelinePublicService/GetNamespaceConnection",
+        "url_pattern": "/vdp.pipeline.v1beta.PipelinePublicService/GetNamespaceConnection",
         "method": "POST",
         "timeout": "5s"
       },


### PR DESCRIPTION
Because

- The `GetNamespaceConnection` endpoint returns `UNIMPLEMENTED`.

This commit

- Fix route.
