### PR TITLE
fix(metric): reintroduce /metrics/vdp/pipeline/triggers endpoint

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -219,6 +219,17 @@
         ]
       },
       {
+        "endpoint": "/v1beta/metrics/vdp/pipeline/triggers",
+        "url_pattern": "/v1beta/metrics/vdp/pipeline/triggers",
+        "method": "GET",
+        "timeout": "30s",
+        "input_query_strings": [
+          "pageSize",
+          "pageToken",
+          "filter"
+        ]
+      },
+      {
         "endpoint": "/v1beta/metrics/vdp/pipeline/tables",
         "url_pattern": "/v1beta/metrics/vdp/pipeline/tables",
         "method": "GET",
@@ -407,6 +418,12 @@
       {
         "endpoint": "/core.mgmt.v1beta.MgmtPublicService/GetPipelineTriggerCount",
         "url_pattern": "/core.mgmt.v1beta.MgmtPublicService/GetPipelineTriggerCount",
+        "method": "POST",
+        "timeout": "30s"
+      },
+      {
+        "endpoint": "/core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords",
+        "url_pattern": "/core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords",
         "method": "POST",
         "timeout": "30s"
       },


### PR DESCRIPTION
Because

- Pipeline metrics list endpoint was removed but it has a client.

This commit

- Reintroduces the endpoint contract. It will be removed with the new
  dashboard design.
