### PR TITLE
chore(test): inject variables to `instill-core` to test OAuth support

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -78,7 +78,10 @@ jobs:
           envFile: .env
 
       - name: Launch Instill Core (latest)
+        # CFG_COMPONENT_SECRETS_GITHUB* variables are injected to test OAuth
+        # connection creation on `pipeline-backend`.
         run: |
+          sed -i 's/\(\w\+GITHUB\w\+\)=/\1=foo/' .env.component
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           RAY_LATEST_TAG=latest \


### PR DESCRIPTION
Because

- https://github.com/instill-ai/pipeline-backend/pull/791 introduced a environment variable dependency in the integration tests.

This commit

- Adds the environment variable to `instill-cloud` setup in CI.
