### PR TITLE
feat(vdp): expose webhook dispatcher endpoint

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1392,6 +1392,13 @@
     ],
     "webhook": [
       {
+        "endpoint": "/v1beta/pipeline-webhooks/{webhook_id}",
+        "url_pattern": "/v1beta/pipeline-webhooks/{webhook_id}",
+        "method": "POST",
+        "timeout": "3600s",
+        "input_query_strings": []
+      },
+      {
         "endpoint": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/events",
         "url_pattern": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/events",
         "method": "POST",


### PR DESCRIPTION
Because

 - A new webhook dispatcher endpoint has been added.

This commit

 - Exposes the webhook dispatcher endpoint.