### PR TITLE
fix(blob): remove auth for using upload and download url

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -34,7 +34,7 @@
     {{ template "influxdb_metrics.tmpl" . }},
     {{ template "cors.tmpl" . }},
     "plugin/http-server": {
-      "name": ["blob","sse-streaming", "multi-auth", "grpc-proxy-server", "registry"],
+      "name": ["sse-streaming", "multi-auth", "grpc-proxy-server", "registry","blob"],
       "multi-auth":{
         "grpc_server": "{{ .plugins.mgmt_public_hostport }}"
       },

--- a/plugins/blob/handler.go
+++ b/plugins/blob/handler.go
@@ -81,17 +81,6 @@ func (rh *blobHandler) handler(ctx context.Context) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		Info(req.Method+" "+req.URL.Path, " start relaying request to blob backend")
 
-		userUID := req.Header.Get("Instill-User-Uid")
-
-		// check if the userUID is a valid uuid
-		if _, err := uuid.FromString(userUID); err != nil {
-			Error(req.URL.Path, " authorization failed. ", err)
-			rh.handleError(req, w, err)
-			return
-		}
-
-		// TODO: check if user uuid is member of the namespace or user self
-
 		// NOTE: the object url uid is the last part of the request path
 		parts := strings.Split(req.URL.Path, "/")
 		objectURLUID := parts[len(parts)-1]


### PR DESCRIPTION
Because

we try to allow use to directly use url

This commit

removes the authorization while uploading and downloading
