### PR TITLE
chore(vdp): remove old webhook endpoints

### DIFF
--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -1366,31 +1366,11 @@
     ],
     "webhook": [
       {
-        "endpoint": "/v1beta/pipeline-webhooks/{webhook_id}",
-        "url_pattern": "/v1beta/pipeline-webhooks/{webhook_id}",
+        "endpoint": "/v1beta/pipeline-webhooks/{webhook_type}",
+        "url_pattern": "/v1beta/pipeline-webhooks/{webhook_type}",
         "method": "POST",
         "timeout": "3600s",
         "input_query_strings": []
-      },
-      {
-        "endpoint": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/events",
-        "url_pattern": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/events",
-        "method": "POST",
-        "timeout": "3600s",
-        "input_query_strings": [
-          "event",
-          "code"
-        ]
-      },
-      {
-        "endpoint": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/events",
-        "url_pattern": "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/events",
-        "method": "POST",
-        "timeout": "3600s",
-        "input_query_strings": [
-          "event",
-          "code"
-        ]
       }
     ],
     "grpc_auth": [


### PR DESCRIPTION
Because

- The old webhook endpoints are deprecated and no longer in use.

This commit

- Removes the outdated webhook endpoints.