### PR TITLE
feat(artifact): add move file endpoint

### DIFF
--- a/config/.env.envsubst
+++ b/config/.env.envsubst
@@ -1,4 +1,5 @@
-# Thie file is used to overwrite the .env file via "make env"
+# This file is used to overwrite the .env file in instill-core
+# https://github.com/instill-ai/instill-core/blob/7b384217dd8fe63f9f4909b90de44bf988131e16/docker-compose.yml#L47-L49
 # given the present environment variables
 
 LOG_LEVEL=${LOG_LEVEL}

--- a/config/settings-env/endpoints.json
+++ b/config/settings-env/endpoints.json
@@ -2950,7 +2950,14 @@
         "endpoint": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files",
         "url_pattern": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files",
         "method": "POST",
-        "timeout": "10s",
+        "timeout": "600s",
+        "input_query_strings": []
+      },
+      {
+        "endpoint": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files:move",
+        "url_pattern": "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files:move",
+        "method": "POST",
+        "timeout": "600s",
         "input_query_strings": []
       },
       {
@@ -3146,7 +3153,13 @@
         "endpoint": "/artifact.artifact.v1alpha.ArtifactPublicService/GetObjectUploadURL",
         "url_pattern": "/artifact.artifact.v1alpha.ArtifactPublicService/GetObjectUploadURL",
         "method": "POST",
-        "timeout": "30s"
+        "timeout": "600s"
+      },
+      {
+        "endpoint": "/artifact.artifact.v1alpha.ArtifactPublicService/MoveFileToCatalog",
+        "url_pattern": "/artifact.artifact.v1alpha.ArtifactPublicService/MoveFileToCatalog",
+        "method": "POST",
+        "timeout": "600s"
       },
       {
         "endpoint": "/artifact.artifact.v1alpha.ArtifactPublicService/GetObjectDownloadURL",


### PR DESCRIPTION
Because
In the one minute impact, the user can move a file from one catalog to another.

This commit
Adds the endpoint to the API gateway.