### PR TITLE
chore(docker): add default KRAKEND_CE_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS krakend_builder
 
 RUN apk --no-cache --virtual .build-deps add git make gcc musl-dev binutils-gold
 
-ARG KRAKEND_CE_VERSION
+ARG KRAKEND_CE_VERSION=2.9.3
 RUN git clone -b v${KRAKEND_CE_VERSION} https://github.com/krakendio/krakend-ce.git /krakend && cd /krakend && make build && cp krakend /usr/bin
 
 


### PR DESCRIPTION
This commit

- adds a default KRAKEND_CE_VERSION, so we don’t need to provide this value from docker-compose in instill-core.