### PR TITLE
fix(security): escape request paths to avoid log injection

### DIFF
--- a/plugins/blob/go.mod
+++ b/plugins/blob/go.mod
@@ -5,6 +5,7 @@ go 1.23.7
 require (
 	github.com/gofrs/uuid/v5 v5.3.2
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241024152819-5ed9f53b5c8a
+	github.com/luraproject/lura/v2 v2.9.1
 	google.golang.org/grpc v1.66.0
 	google.golang.org/protobuf v1.36.3
 )

--- a/plugins/blob/go.sum
+++ b/plugins/blob/go.sum
@@ -6,6 +6,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241024152819-5ed9f53b5c8a h1:FAj25JbB8CUfUbyPAj1PupoFHo9sW5kffjQyVjkXDg4=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241024152819-5ed9f53b5c8a/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/luraproject/lura/v2 v2.9.1 h1:ALN5mn83geDF8AtriMyEJmYFse4wqOxdlB7OjWYwwFg=
+github.com/luraproject/lura/v2 v2.9.1/go.mod h1:MWbT5xuqJkMoUCRo6vvvWZhjRsCpvntEUYrsSGgV3yo=
 golang.org/x/net v0.36.0 h1:vWF2fRbw4qslQsQzgFqZff+BItCvGFQqKzKIzx1rmoA=
 golang.org/x/net v0.36.0/go.mod h1:bFmbeoIPfrw4sMHNhb4J9f6+tPziuGjq7Jk/38fxi1I=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=

--- a/plugins/blob/handler.go
+++ b/plugins/blob/handler.go
@@ -239,7 +239,7 @@ func upload(ctx context.Context, req *http.Request, w http.ResponseWriter, rh *b
 			"bytes transferred, Content-Length:",
 			req.ContentLength,
 			"bytes, Content-Type:",
-			req.Header.Get("Content-Type"),
+			sanitize(req.Header.Get("Content-Type")),
 			", Object UID:",
 			objectURL.GetObjectUid(),
 			", Namespace UID:",

--- a/plugins/registry/handler.go
+++ b/plugins/registry/handler.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"html"
 	"io"
 	"net/http"
 	"regexp"
@@ -117,8 +116,6 @@ type registryHandlerParams struct {
 
 func (rh *registryHandler) handler(ctx context.Context) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		logger.Info(req.Method + " " + html.EscapeString(req.URL.Path))
-
 		// Authenticate the user via docker login
 		username, password, ok := req.BasicAuth()
 		if !ok {
@@ -141,8 +138,7 @@ func (rh *registryHandler) handler(ctx context.Context) http.HandlerFunc {
 			case grpccodes.Unauthenticated:
 				rh.handleError(req, w, authErr)
 			default:
-				logger.Error(html.EscapeString(req.URL.Path), "failed to validate token", err)
-				rh.handleError(req, w, err)
+				rh.handleError(req, w, fmt.Errorf("validating token: %w", err))
 			}
 
 			return
@@ -172,8 +168,7 @@ func (rh *registryHandler) login(ctx context.Context, p registryHandlerParams) {
 	lookupReq := &mgmtpb.LookUpUserAdminRequest{UserUid: p.userUID}
 	userLookup, err := rh.mgmtPrivateClient.LookUpUserAdmin(ctx, lookupReq)
 	if err != nil {
-		logger.Error(html.EscapeString(req.URL.Path), "failed to lookup user", err)
-		rh.handleError(req, w, err)
+		rh.handleError(req, w, fmt.Errorf("looking up user: %w", err))
 		return
 	}
 
@@ -212,8 +207,7 @@ func (rh *registryHandler) relay(ctx context.Context, p registryHandlerParams) {
 
 		resp, err := rh.mgmtPublicClient.ListUserMemberships(ctx, &mgmtpb.ListUserMembershipsRequest{UserId: p.userID})
 		if err != nil {
-			logger.Error(html.EscapeString(req.URL.Path), "failed to check organization", err)
-			rh.handleError(req, w, err)
+			rh.handleError(req, w, fmt.Errorf("checking organization: %w", err))
 			return
 		}
 
@@ -245,11 +239,10 @@ func (rh *registryHandler) relay(ctx context.Context, p registryHandlerParams) {
 		if err != nil {
 			switch grpcstatus.Convert(err).Code() {
 			case grpccodes.NotFound:
-				logger.Warning(html.EscapeString(req.URL.Path), "model", name, "doesn't exist: ", err)
+				logger.Warning(req, "model", name, "doesn't exist: ", err)
 				rh.handleNameUnknown(w, "model "+name+" doesn't exist")
 			default:
-				logger.Error(html.EscapeString(req.URL.Path), "failed to validate namespace", err)
-				rh.handleError(req, w, err)
+				rh.handleError(req, w, fmt.Errorf("validating namespace: %w", err))
 			}
 			return
 		}
@@ -261,8 +254,7 @@ func (rh *registryHandler) relay(ctx context.Context, p registryHandlerParams) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logger.Error(html.EscapeString(req.URL.Path), "failed to relay request", err)
-		rh.handleError(req, w, err)
+		rh.handleError(req, w, fmt.Errorf("relaying request: %w", err))
 		return
 	}
 
@@ -277,8 +269,7 @@ func (rh *registryHandler) relay(ctx context.Context, p registryHandlerParams) {
 			},
 		}
 		if _, err := rh.artifactPrivateClient.CreateRepositoryTag(ctx, createTagReq); err != nil {
-			logger.Error(html.EscapeString(req.URL.Path), "failed to create tag", err)
-			rh.handleError(req, w, err)
+			rh.handleError(req, w, fmt.Errorf("creating tag: %w", err))
 			return
 		}
 
@@ -297,8 +288,7 @@ func (rh *registryHandler) relay(ctx context.Context, p registryHandlerParams) {
 			Version:     resourceID,
 			Digest:      digest,
 		}); err != nil {
-			logger.Error(html.EscapeString(req.URL.Path), "failed to deploy model", err)
-			rh.handleError(req, w, err)
+			rh.handleError(req, w, fmt.Errorf("deploying model: %w", err))
 			return
 		}
 	}
@@ -332,10 +322,10 @@ var (
 )
 
 func (rh *registryHandler) handleError(req *http.Request, w http.ResponseWriter, e error) {
-	logger.Warning(html.EscapeString(req.URL.Path), e)
+	logWarning(req, e)
 
 	if err := errcode.ServeJSON(w, e); err != nil {
-		logger.Error(html.EscapeString(req.URL.Path), "failed to handle error", e)
+		logError(req, "failed to handle error;", "original error:", e, ", failure reason:", err)
 	}
 }
 


### PR DESCRIPTION
Because

- 2 vulnerabilities related to log injection have been detected:
  - https://github.com/instill-ai/api-gateway/security/code-scanning/7
  - https://github.com/instill-ai/api-gateway/security/code-scanning/6

This commit

- Escapes input URL paths and headers before logging them
- Unifies the logging strategy across plugins