### PR TITLE
ci(workflows): add rc image build and push

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -2,6 +2,13 @@ name: Build and Push Images
 
 on:
   workflow_call:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
+    tags:
+      - "*-rc"
   release:
     types: [published]
 
@@ -27,6 +34,17 @@ jobs:
           username: drop@instill-ai.com
           password: ${{ secrets.botDockerHubPassword }}
 
+      - name: Set Versions
+        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/github-script@v6
+        id: set_version
+        with:
+          script: |
+            const tag = '${{ github.ref_name }}'
+            const no_v_tag = tag.replace('v', '')
+            core.setOutput('tag', tag)
+            core.setOutput('no_v_tag', no_v_tag)
+
       - name: Build and push (latest)
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
@@ -43,17 +61,21 @@ jobs:
           cache-from: type=registry,ref=instill/api-gateway:buildcache
           cache-to: type=registry,ref=instill/api-gateway:buildcache,mode=max
 
-      - name: Set Versions
-        if: github.event_name == 'release'
-        uses: actions/github-script@v6
-        id: set_version
+      - name: Build and push (rc)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v6
         with:
-          script: |
-            const tag = '${{ github.ref_name }}'
-            const no_v_tag = tag.replace('v', '')
-            core.setOutput('tag', tag)
-            core.setOutput('no_v_tag', no_v_tag)
-
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: true
+          build-args: |
+            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
+            KRAKEND_CE_VERSION=${{ env.KRAKEND_CE_VERSION }}
+            SERVICE_NAME=api-gateway
+          tags: instill/api-gateway:${{steps.set_version.outputs.no_v_tag}}-rc
+          cache-from: type=registry,ref=instill/api-gateway:buildcache
+          cache-to: type=registry,ref=instill/api-gateway:buildcache,mode=max
       - name: Build and push (release)
         if: github.event_name == 'release'
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Because

- we are going to introduce `rc` (release candidate) stage to enhance the robustness of our release cycle.

This commit

- implement the logic:
  - `git tag <next-release-version>-rc && git push origin <next-release-version>-rc` triggers the `rc` image build and push flow.
