### PR TITLE
ci(workflows): fix rc image tag

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -61,8 +61,8 @@ jobs:
           cache-from: type=registry,ref=instill/api-gateway:buildcache
           cache-to: type=registry,ref=instill/api-gateway:buildcache,mode=max
 
-      - name: Build and push (rc)
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Build and push (rc/release)
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
@@ -72,22 +72,7 @@ jobs:
             GOLANG_VERSION=${{ env.GOLANG_VERSION }}
             ALPINE_VERSION=${{ env.ALPINE_VERSION }}
             KRAKEND_CE_VERSION=${{ env.KRAKEND_CE_VERSION }}
-            SERVICE_NAME=api-gateway
-          tags: instill/api-gateway:${{steps.set_version.outputs.no_v_tag}}-rc
-          cache-from: type=registry,ref=instill/api-gateway:buildcache
-          cache-to: type=registry,ref=instill/api-gateway:buildcache,mode=max
-      - name: Build and push (release)
-        if: github.event_name == 'release'
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          push: true
-          build-args: |
-            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
-            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
-            KRAKEND_CE_VERSION=${{ env.KRAKEND_CE_VERSION }}
-            SERVICE_NAME=api-gateway
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
           tags: instill/api-gateway:${{steps.set_version.outputs.no_v_tag}}
           cache-from: type=registry,ref=instill/api-gateway:buildcache
           cache-to: type=registry,ref=instill/api-gateway:buildcache,mode=max


### PR DESCRIPTION
Because

- git tag contains `-rc` suffix already.

This commit

- removed the redundant `-rc` suffix and combine the `rc` and `release` step.
