### PR TITLE
chore(blob): allow file be previewed in browser

### DIFF
--- a/plugins/blob/handler.go
+++ b/plugins/blob/handler.go
@@ -328,7 +328,7 @@ func download(_ context.Context, req *http.Request, w http.ResponseWriter, rh *b
 	}
 
 	// set attachment header
-	w.Header().Set("Content-Disposition", "attachment; filename="+object.GetName())
+	w.Header().Set("Content-Disposition", "inline; filename="+object.GetName())
 
 	w.WriteHeader(newResp.StatusCode)
 


### PR DESCRIPTION
Because

- we want the file to be previewed in the browser

This commit

- allows the file to be previewed in the browser by setting the `Content-Disposition` header to `inline`