### PR TITLE
feat(plugin): support new blob-url path

### DIFF
--- a/plugins/blob/main.go
+++ b/plugins/blob/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"html"
+	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/luraproject/lura/v2/logging"
@@ -34,6 +37,57 @@ func (r blob) registerHandlers(ctx context.Context, extra map[string]any, h http
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		parts := strings.Split(req.URL.Path, "/")
+
+		// TODO: we should be able to implement this to directly rely on KrakenD instead of writing our own proxy.
+
+		// We encode the MinIO presigned URL to a base64 string in the format:
+		// schema://host:port/v1alpha/blob-urls/base64_encoded_presigned_url
+		// Here in this plugin, we decode the base64 string to the presigned URL
+		// and forward the request to MinIO.
+		if len(parts) > 2 && parts[2] == "blob-urls" {
+
+			blobURLBytes, err := base64.StdEncoding.DecodeString(parts[3])
+			if err != nil {
+				return
+			}
+			blobURL, err := url.Parse(string(blobURLBytes))
+			if err != nil {
+				return
+			}
+			blobURL.Scheme = "http"
+			req.Header.Set("host", blobURL.Host)
+			req.Host = blobURL.Host
+			req.URL = blobURL
+			req.RequestURI = ""
+			req.Header.Del("Authorization")
+			resp, err := http.DefaultClient.Do(req)
+
+			if err != nil {
+				http.Error(w, "Failed to proxy request", http.StatusInternalServerError)
+				return
+			}
+			defer resp.Body.Close()
+
+			// Copy response headers
+			for k, hs := range resp.Header {
+				if k != "Access-Control-Allow-Origin" {
+					for _, h := range hs {
+						w.Header().Add(k, h)
+					}
+				}
+			}
+
+			// Set status code
+			w.WriteHeader(resp.StatusCode)
+
+			// Stream response body
+			_, err = io.Copy(w, resp.Body)
+			if err != nil {
+				logger.Error(logPrefix, "Failed to stream response body:", err)
+			}
+			return
+		}
+
 		if len(parts) < 6 || parts[1] != "v1alpha" || parts[2] != "namespaces" || parts[4] != "blob-urls" {
 			h.ServeHTTP(w, req)
 			return


### PR DESCRIPTION
Because

- we want to simplify file upload/download flows by leveraging MinIO’s built-in authentication and expiration mechanisms in the pre-signed URL

This commit

- decodes the new blob-url and directly forward it to MinIO