### PR TITLE
fix(plugin): use URLEncoding to decode blob URL

### DIFF
--- a/plugins/blob/main.go
+++ b/plugins/blob/main.go
@@ -44,7 +44,7 @@ func (r blob) registerHandlers(ctx context.Context, extra map[string]any, h http
 		// schema://host:port/v1alpha/blob-urls/base64_encoded_presigned_url
 		// Here in this plugin, we decode the base64 string to the presigned URL
 		// and forward the request to MinIO.
-		if len(parts) > 2 && parts[2] == "blob-urls" {
+		if len(parts) > 3 && parts[2] == "blob-urls" {
 			blobURLBytes, err := base64.URLEncoding.DecodeString(parts[3])
 			if err != nil {
 				return


### PR DESCRIPTION
Because

- base64.StdEncoding might generate `/` in the Base64 string, which can break the structure of the generated blob URL.

This commit:

- Uses base64.URLEncoding to decode the blob URL.