### PR TITLE
chore(docker): download compiler from musl.cc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ARG BUILDARCH
 
 RUN if [[ "$BUILDARCH" = "amd64" && "$TARGETARCH" = "arm64" ]] ; \
     then \
-    curl -sL https://artifacts.instill-ai.com/github-actions/aarch64-linux-musl-cross.tgz | \
+    curl -sL http://musl.cc/aarch64-linux-musl-cross.tgz | \
     tar zx; \
     fi
 


### PR DESCRIPTION
Because

- the original musl download link has been unblocked.

This commit

- downloads compiler from musl.cc
