### PR TITLE
ci(github): trigger instill-core sync after image build

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo "COMMIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - name: Build and push (latest)
+      - name: Build and push (commit hash and latest)
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
@@ -51,7 +51,9 @@ jobs:
             GOLANG_VERSION=${{ env.GOLANG_VERSION }}
             ALPINE_VERSION=${{ env.ALPINE_VERSION }}
             KRAKEND_CE_VERSION=${{ env.KRAKEND_CE_VERSION }}
-          tags: instill/api-gateway:latest
+          tags: |
+            instill/api-gateway:${{ env.COMMIT_SHORT_SHA }}
+            instill/api-gateway:latest
           cache-from: type=registry,ref=instill/api-gateway:buildcache
           cache-to: type=registry,ref=instill/api-gateway:buildcache,mode=max
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -91,20 +91,20 @@ jobs:
             KRAKEND_CE_VERSION=${{ env.KRAKEND_CE_VERSION }}
             SERVICE_NAME=${{ env.SERVICE_NAME }}
             SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
-          tags: instill/api-gateway:latest
+          tags: instill/api-gateway:${{ env.COMMIT_SHORT_SHA }}
           cache-from: |
             type=registry,ref=instill/api-gateway:buildcache
           cache-to: |
             type=registry,ref=instill/api-gateway:buildcache,mode=max
 
-      - name: Launch Instill Core CE (latest)
+      - name: Launch Instill Core CE (commit hash)
         working-directory: instill-core
         run: |
           # CFG_COMPONENT_SECRETS_GITHUB* variables are injected to test OAuth
           # connection creation on `pipeline-backend`.
           make latest EDITION=local-ce:test ENV_SECRETS_COMPONENT=.env.secrets.component.test
 
-      - name: Run ${{ matrix.component }} integration test (latest)
+      - name: Run ${{ matrix.component }} integration test (commit hash)
         run: |
           git clone https://github.com/instill-ai/${{ matrix.component }}.git
           cd ${{ matrix.component }}

--- a/.github/workflows/sync-instill-core.yml
+++ b/.github/workflows/sync-instill-core.yml
@@ -1,0 +1,17 @@
+name: Sync Instill Core Version
+
+on:
+  workflow_run:
+    workflows: ["Build and Push Images"]
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  update-version:
+    uses: instill-ai/instill-core/.github/workflows/update-service-version.yml@main
+    with:
+      service: api-gateway
+    secrets:
+      botGitHubToken: ${{ secrets.botGitHubToken }} 


### PR DESCRIPTION
Because

- we want to automatically sync the image hash or tag to the instill-core repository.

This commit

- triggers the instill-core sync after the image is built.